### PR TITLE
Invoke fz_close_device() before fz_drop_device() to fix #19.

### DIFF
--- a/pdf_document.cpp
+++ b/pdf_document.cpp
@@ -95,6 +95,7 @@ extern "C" {
 #if MUPDF_VERSION < 10010
 #  define fz_new_draw_device(context, transform, dest) \
        (fz_new_draw_device(context, dest))
+#  define fz_close_device(context, dev)
 #endif
 
 const char* const PDFDocument::DEFAULT_ROOT_OUTLINE_ITEM_TITLE =
@@ -195,6 +196,7 @@ void PDFDocument::Render(
   });
 
   // 4. Clean up.
+  fz_close_device(_fz_context, dev);
   fz_drop_device(_fz_context, dev);
   fz_drop_pixmap(_fz_context, pixmap);
 }


### PR DESCRIPTION
It appears that a new requirement was added in MuPDF 1.10 that
fz_close_device() must first be called before fz_drop_device(), or a
warning will be printed to the console. This was reported as issue #19.

This commit adds this call for MuPDF >= 1.10.

Also see:

  - https://www.netbsd.org/~leot/tmp/zathura/0001-utils.c-also-call-fz_close_device-before-dropping-it.patch
  - https://ghostscript.com/pipermail/gs-cvs/2016-July/020238.html