### PR TITLE
Fix JPEG loading error.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
           dpkg-deb -I upload/*.deb &&
           dpkg-deb -c upload/*.deb
       - name: Install package
-        run: sudo dpkg -i upload/*.deb
+        run: sudo apt install -y ./upload/*.deb
       - name: Check help message
         run: jfbview -h || true
 

--- a/packaging/build-rpm.sh
+++ b/packaging/build-rpm.sh
@@ -11,7 +11,7 @@ yum install -y epel-release
 yum install -y \
   cmake make gcc-c++ rpm-build \
   ncurses-devel imlib2-devel \
-  mesa-libGLU-devel libXi-devel libXrandr-devel
+  libjpeg-devel mesa-libGLU-devel libXi-devel libXrandr-devel
 
 cd "$(dirname "$0")/.."
 mkdir -p build upload

--- a/packaging/run-tests-deb.sh
+++ b/packaging/run-tests-deb.sh
@@ -33,5 +33,6 @@ cmake -H. -Bbuild_tests \
   -DCMAKE_BUILD_TYPE=Debug \
   -DCMAKE_VERBOSE_MAKEFILE=ON
 cmake --build build_tests
-cmake --build build_tests --target test
+env CTEST_OUTPUT_ON_FAILURE=1 \
+  cmake --build build_tests --target test
 

--- a/tests/image_document_test.cpp
+++ b/tests/image_document_test.cpp
@@ -4,6 +4,7 @@
 
 // Must include AFTER gtest as Xlib macros conflict with gtest.
 #include "../src/image_document.hpp"
+#include "../src/pdf_document.hpp"
 
 TEST(ImageDocument, ReturnsNullptrIfLoadingEmptyImage) {
   std::unique_ptr<Document> doc(ImageDocument::Open(""));
@@ -24,5 +25,13 @@ TEST(ImageDocument, CanLoadJPEGImage) {
   EXPECT_EQ(doc->GetNumPages(), 1);
   EXPECT_EQ(doc->GetPageSize(0).Width, 320);
   EXPECT_EQ(doc->GetPageSize(0).Height, 400);
+}
+
+// This is not a real test but ensures that MuPDF is actually linked with this
+// test binary. The reason is that both MuPDF and Imlib2 ship with libjpeg /
+// libjpeg-turbo, and this has historically caused errors when loading a JPEG
+// image through Imlib2.
+TEST(ImageDocument, EnsureMuPDFLinkage) {
+  std::unique_ptr<Document> doc(PDFDocument::Open(""));
 }
 

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,3 +1,12 @@
+# Dependencies.
+# -------------
+find_package(JPEG REQUIRED)
+
+# MuPDF provides its own version of libjpeg in thirdparty. However, we are
+# linking against the system version of Imlib2, which links against the system
+# version of libjpeg. Using the bundled version of libjpeg here will cause a
+# conflict with the system version of libjpeg and cause Imlib2 to fail. This
+# manifests as an "unknown error" when attempting to load a JPEG file.
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/mupdf"
   COMMAND
@@ -8,6 +17,7 @@ add_custom_command(
   COMMAND
     make
       "USE_SYSTEM_LIBS=no"
+      "USE_SYSTEM_LIBJPEG=yes"
       "prefix=${CMAKE_CURRENT_BINARY_DIR}/mupdf"
       install
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mupdf"
@@ -16,7 +26,18 @@ add_custom_target(
   vendor_mupdf
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/mupdf"
 )
-set(vendor_mupdf_include_dirs "${CMAKE_CURRENT_BINARY_DIR}/mupdf/include" PARENT_SCOPE)
+set(
+  vendor_mupdf_include_dirs
+  "${CMAKE_CURRENT_BINARY_DIR}/mupdf/include"
+  "${JPEG_INCLUDE_DIR}"
+  PARENT_SCOPE
+)
 set(vendor_mupdf_link_dirs "${CMAKE_CURRENT_BINARY_DIR}/mupdf/lib" PARENT_SCOPE)
-set(vendor_mupdf_libs "mupdf" "mupdf-third" PARENT_SCOPE)
+set(
+  vendor_mupdf_libs
+  "mupdf"
+  "mupdf-third"
+  ${JPEG_LIBRARIES}
+  PARENT_SCOPE
+)
 


### PR DESCRIPTION
Previously, we were building MuPDF along with its own version of libjpeg in thirdparty. However, we are linking against the system version of Imlib2, which links against the system version of libjpeg. Building MuPDF with the bundled version of libjpeg causes a conflict with the system version of libjpeg and causes Imlib2 to fail when loading a JPEG file.