### PR TITLE
Fix Travis CI deploy to GCS failure on ARM64 due to PR #46.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,14 +75,17 @@ cache:
   directories:
     - vendor/mupdf/build
     - vendor/.mtime_cache
+before_deploy: |
+  sudo chown -R "${USER}" upload && \
+  mkdir upload-gcs && \
+  mv upload "upload-gcs/${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}"
 deploy:
+  skip_cleanup: true
   provider: gcs
-  edge: true
   access_key_id: ${GCS_ACCESS_KEY_ID}
   secret_access_key: ${GCS_SECRET_ACCESS_KEY}
   bucket: ${GCS_BUCKET}
-  local_dir: upload
-  upload_dir: "${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}"
+  local_dir: upload-gcs
   on:
     repo: jichu4n/jfbview
     all_branches: true


### PR DESCRIPTION
In PR #46, we switched to using dpl v2 for uploading build artifacts to Google Cloud Storage. However this results in the following error on     ARM64 platforms:

```
$ curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz | tar xz -C ~ && ~/google-cloud-sdk/install.sh --path-update false --usage-reporting false --command-completion false
######################################################################## 100.0%
Welcome to the Google Cloud SDK!
ERROR: (gcloud.components.update) The following components are unknown [anthoscli].
This will install all the core command line tools necessary for working with
the Google Cloud Platform.
```
