### PR TITLE
Add inverted and sepia color modes.

### DIFF
--- a/doc/jfbview.1
+++ b/doc/jfbview.1
@@ -33,6 +33,12 @@ Start in zoom-to-width mode. This is the default.
 \fB--rotation=\fRn, \fB-r\fR n
 Set initial rotation to n degrees clockwise.
 .TP
+\fB--color_mode=\fRinvert, \fB-c\fR invert
+Start in inverted color mode.
+.TP
+\fB--color_mode=\fRsepia, \fB-c\fR sepia
+Start in sepia color mode.
+.TP
 \fB--format=image\fR
 Forces the program to treat the input file as an image.
 .TP

--- a/doc/jfbview.1
+++ b/doc/jfbview.1
@@ -113,8 +113,11 @@ Set zoom to n percent.
 \fBe\fR
 Reload current file from disk.
 .TP
-\fBi\fR
-Toggle inverted colors.
+\fBI\fR
+Toggle inverted color mode.
+.TP
+\fBS\fR
+Toggle sepia color mode.
 .SH KEY BINDINGS - OUTLINE VIEW
 The outline view is toggled by the \fBTab\fR key.
 .TP

--- a/doc/jfbview.1
+++ b/doc/jfbview.1
@@ -112,6 +112,9 @@ Set zoom to n percent.
 .TP
 \fBe\fR
 Reload current file from disk.
+.TP
+\fBi\fR
+Toggle inverted colors.
 .SH KEY BINDINGS - OUTLINE VIEW
 The outline view is toggled by the \fBTab\fR key.
 .TP

--- a/doc/jfbview.1.html
+++ b/doc/jfbview.1.html
@@ -111,7 +111,9 @@
 
        <B>e</B>      Reload current file from disk.
 
-       <B>i</B>      Toggle inverted colors.
+       <B>I</B>      Toggle inverted color mode.
+
+       <B>S</B>      Toggle sepia color mode.
 
 <B>KEY</B> <B>BINDINGS</B> <B>-</B> <B>OUTLINE</B> <B>VIEW</B>
        The outline view is toggled by the <B>Tab</B> key.

--- a/doc/jfbview.1.html
+++ b/doc/jfbview.1.html
@@ -111,6 +111,8 @@
 
        <B>e</B>      Reload current file from disk.
 
+       <B>i</B>      Toggle inverted colors.
+
 <B>KEY</B> <B>BINDINGS</B> <B>-</B> <B>OUTLINE</B> <B>VIEW</B>
        The outline view is toggled by the <B>Tab</B> key.
 

--- a/doc/jfbview.1.html
+++ b/doc/jfbview.1.html
@@ -42,6 +42,12 @@
        <B>--rotation=</B>n, <B>-r</B> n
               Set initial rotation to n degrees clockwise.
 
+       <B>--color_mode=</B>invert, <B>-c</B> invert
+              Start in inverted color mode.
+
+       <B>--color_mode=</B>sepia, <B>-c</B> sepia
+              Start in sepia color mode.
+
        <B>--format=image</B>
               Forces the program to treat the input file as an image.
 

--- a/src/document.hpp
+++ b/src/document.hpp
@@ -21,8 +21,9 @@
 #ifndef DOCUMENT_HPP
 #define DOCUMENT_HPP
 
-#include <string>
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 // An abstraction for a document.
@@ -34,8 +35,7 @@ class Document {
     int Height;
 
     explicit PageSize(int width = -1, int height = -1)
-        : Width(width), Height(height) {
-    }
+        : Width(width), Height(height) {}
   };
 
   // An interface for a callback that stores a pixel in a memory buffer.
@@ -43,7 +43,7 @@ class Document {
    public:
     // Writes a pixel value (r, g, b) to position (x, y). It is important that
     // Write be thread-safe when called with different (x, y).
-    virtual void Write(int x, int y, int r, int g, int b) = 0;
+    virtual void Write(int x, int y, uint8_t r, uint8_t g, uint8_t b) = 0;
   };
 
   // An item in a outline. An item may contain further children items.
@@ -73,13 +73,11 @@ class Document {
     int SearchStringPosition;
 
     explicit SearchHit(
-        int page = -1,
-        const std::string& context_text = std::string(),
+        int page = -1, const std::string& context_text = std::string(),
         int search_string_position = -1)
         : Page(page),
           ContextText(context_text),
-          SearchStringPosition(search_string_position) {
-    }
+          SearchStringPosition(search_string_position) {}
   };
   struct SearchResult {
     // The search string.
@@ -119,9 +117,7 @@ class Document {
   // Searches the text of the document. Will return up to max_num_search_hits
   // search hits starting from the given page.
   SearchResult Search(
-      const std::string& search_string,
-      int start_page,
-      int context_length,
+      const std::string& search_string, int start_page, int context_length,
       int max_num_search_hits);
 
  protected:

--- a/src/framebuffer.cpp
+++ b/src/framebuffer.cpp
@@ -141,9 +141,12 @@ int Framebuffer::Format::GetDepth() const {
   return (_vinfo.bits_per_pixel + 7) >> 3;
 }
 
-uint32_t Framebuffer::Format::Pack(int r, int g, int b) const {
-  return ((r >> (8 - _vinfo.red.length)) << _vinfo.red.offset) |
-         ((g >> (8 - _vinfo.green.length)) << _vinfo.green.offset) |
-         ((b >> (8 - _vinfo.blue.length)) << _vinfo.blue.offset);
+uint32_t Framebuffer::Format::Pack(uint8_t r, uint8_t g, uint8_t b) const {
+  return ((static_cast<uint32_t>(r) >> (8 - _vinfo.red.length))
+          << _vinfo.red.offset) |
+         ((static_cast<uint32_t>(g) >> (8 - _vinfo.green.length))
+          << _vinfo.green.offset) |
+         ((static_cast<uint32_t>(b) >> (8 - _vinfo.blue.length))
+          << _vinfo.blue.offset);
 }
 

--- a/src/framebuffer.hpp
+++ b/src/framebuffer.hpp
@@ -22,8 +22,8 @@
 #define FRAMEBUFFER_HPP
 
 #include <linux/fb.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -72,7 +72,7 @@ class Framebuffer {
     // See PixelBuffer::Format.
     int GetDepth() const override;
     // See PixelBuffer::Format.
-    uint32_t Pack(int r, int g, int b) const override;
+    uint32_t Pack(uint8_t r, uint8_t g, uint8_t b) const override;
 
    private:
     fb_var_screeninfo _vinfo;

--- a/src/image_document.cpp
+++ b/src/image_document.cpp
@@ -24,7 +24,6 @@
 
 #include "image_document.hpp"
 
-#include <stdint.h>
 // For the M_PI constant.
 #define _USE_MATH_DEFINES
 #include <algorithm>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -459,12 +459,21 @@ class ReloadCommand : public StateCommand {
   }
 };
 
-class ToggleInvertColorsCommand : public Command {
+class ToggleInvertedColorModeCommand : public Command {
  public:
   void Execute(int repeat, State* state) override {
-    state->ColorMode = state->ColorMode == Viewer::ColorMode::INVERT_COLORS
+    state->ColorMode = state->ColorMode == Viewer::ColorMode::INVERTED
                            ? Viewer::ColorMode::NORMAL
-                           : Viewer::ColorMode::INVERT_COLORS;
+                           : Viewer::ColorMode::INVERTED;
+  }
+};
+
+class ToggleSepiaColorModeCommand : public Command {
+ public:
+  void Execute(int repeat, State* state) override {
+    state->ColorMode = state->ColorMode == Viewer::ColorMode::SEPIA
+                           ? Viewer::ColorMode::NORMAL
+                           : Viewer::ColorMode::SEPIA;
   }
 };
 
@@ -674,7 +683,8 @@ std::unique_ptr<Registry> BuildRegistry() {
 
   registry->Register('e', std::move(std::make_unique<ReloadCommand>()));
 
-  registry->Register('i', std::make_unique<ToggleInvertColorsCommand>());
+  registry->Register('I', std::make_unique<ToggleInvertedColorModeCommand>());
+  registry->Register('S', std::make_unique<ToggleSepiaColorModeCommand>());
 
   return registry;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -459,6 +459,15 @@ class ReloadCommand : public StateCommand {
   }
 };
 
+class ToggleInvertColorsCommand : public Command {
+ public:
+  void Execute(int repeat, State* state) override {
+    state->ColorMode = state->ColorMode == Viewer::ColorMode::INVERT_COLORS
+                           ? Viewer::ColorMode::NORMAL
+                           : Viewer::ColorMode::INVERT_COLORS;
+  }
+};
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *                               END COMMANDS                                *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -628,8 +637,9 @@ std::unique_ptr<Registry> BuildRegistry() {
       KEY_RIGHT, std::move(std::make_unique<MoveRightCommand>()));
   registry->Register(' ', std::move(std::make_unique<ScreenDownCommand>()));
   registry->Register(
-      6, std::move(std::make_unique<ScreenDownCommand>()));               // ^F
-  registry->Register(2, std::move(std::make_unique<ScreenUpCommand>()));  // ^B
+      6 /* CTRL-F */, std::move(std::make_unique<ScreenDownCommand>()));  // ^F
+  registry->Register(
+      2 /* CTRL-B */, std::move(std::make_unique<ScreenUpCommand>()));  // ^B
   registry->Register('J', std::move(std::make_unique<PageDownCommand>()));
   registry->Register(KEY_NPAGE, std::move(std::make_unique<PageDownCommand>()));
   registry->Register('K', std::move(std::make_unique<PageUpCommand>()));
@@ -663,6 +673,8 @@ std::unique_ptr<Registry> BuildRegistry() {
   registry->Register('`', std::move(std::make_unique<RestoreStateCommand>()));
 
   registry->Register('e', std::move(std::make_unique<ReloadCommand>()));
+
+  registry->Register('i', std::make_unique<ToggleInvertColorsCommand>());
 
   return registry;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -499,6 +499,10 @@ static const char* HELP_STRING =
     "\t--zoom_to_fit         Start in automatic zoom-to-fit mode.\n"
     "\t--zoom_to_width       Start in automatic zoom-to-width mode.\n"
     "\t--rotation=N, -r N    Set initial rotation to N degrees clockwise.\n"
+    "\t--color_mode=invert, -c invert\n"
+    "\t                      Start in inverted color mode.\n"
+    "\t--color_mode=sepia, -c sepia\n"
+    "\t                      Start in sepia color mode.\n"
 #ifndef JFBVIEW_NO_IMLIB2
     "\t--format=image, -f image\n"
     "\t                      Forces the program to treat the input file as an\n"
@@ -538,12 +542,13 @@ static void ParseCommandLine(int argc, char* argv[], State* state) {
       {"zoom_to_width", false, nullptr, ZOOM_TO_WIDTH},
       {"zoom_to_fit", false, nullptr, ZOOM_TO_FIT},
       {"rotation", true, nullptr, 'r'},
+      {"color_mode", true, nullptr, 'c'},
       {"format", true, nullptr, 'f'},
       {"cache_size", true, nullptr, RENDER_CACHE_SIZE},
       {"fb_debug_info", false, nullptr, PRINT_FB_DEBUG_INFO_AND_EXIT},
       {0, 0, 0, 0},
   };
-  static const char* ShortFlags = "hP:p:z:r:f:";
+  static const char* ShortFlags = "hP:p:z:r:c:f:";
 
   for (;;) {
     int opt_char = getopt_long(argc, argv, ShortFlags, LongFlags, nullptr);
@@ -605,6 +610,20 @@ static void ParseCommandLine(int argc, char* argv[], State* state) {
           exit(EXIT_FAILURE);
         }
         break;
+      case 'c': {
+        const std::string arg = ToLower(optarg);
+        if (arg == "normal" || arg == "") {
+          state->ColorMode = Viewer::ColorMode::NORMAL;
+        } else if (arg == "invert" || arg == "inverted") {
+          state->ColorMode = Viewer::ColorMode::INVERTED;
+        } else if (arg == "sepia") {
+          state->ColorMode = Viewer::ColorMode::SEPIA;
+        } else {
+          fprintf(stderr, "Invalid color mode \"%s\"\n", optarg);
+          exit(EXIT_FAILURE);
+        }
+        break;
+      }
       case PRINT_FB_DEBUG_INFO_AND_EXIT:
         state->PrintFBDebugInfoAndExit = true;
         break;

--- a/src/pdf_document.cpp
+++ b/src/pdf_document.cpp
@@ -19,8 +19,6 @@
 // This file defines PDFDocument, an implementation of the Document abstraction
 // using MuPDF.
 
-#include <stdint.h>
-
 #include <algorithm>
 #include <cassert>
 #include <cstring>

--- a/src/pixel_buffer.cpp
+++ b/src/pixel_buffer.cpp
@@ -71,7 +71,7 @@ PixelBuffer::Rect PixelBuffer::GetRect() const {
   return Rect(0, 0, _size.Width, _size.Height);
 }
 
-void PixelBuffer::WritePixel(int x, int y, int r, int g, int b) {
+void PixelBuffer::WritePixel(int x, int y, uint8_t r, uint8_t g, uint8_t b) {
   _pixel_writer_impl->WritePixel(_format->Pack(r, g, b), GetPixelAddress(x, y));
 }
 

--- a/src/pixel_buffer.hpp
+++ b/src/pixel_buffer.hpp
@@ -22,7 +22,7 @@
 #ifndef PIXEL_BUFFER_HPP
 #define PIXEL_BUFFER_HPP
 
-#include <stdint.h>
+#include <cstdint>
 
 // A class that represents a rectangular matrix of pixels.
 class PixelBuffer {
@@ -40,7 +40,7 @@ class PixelBuffer {
     // Length of a pixel, in bytes. Must be between 0 and 4.
     virtual int GetDepth() const = 0;
     // Method to pack an RGB tuple into a pixel value.
-    virtual uint32_t Pack(int r, int g, int b) const = 0;
+    virtual uint32_t Pack(uint8_t r, uint8_t g, uint8_t b) const = 0;
     // This is required to keep C++ happy.
     virtual ~Format() {}
   };
@@ -72,7 +72,7 @@ class PixelBuffer {
   Rect GetRect() const;
 
   // Writes a pixel value to a location in the buffer.
-  void WritePixel(int x, int y, int r, int g, int b);
+  void WritePixel(int x, int y, uint8_t r, uint8_t g, uint8_t b);
 
   // Copies a region in the current pixel buffer to another pixel buffer. The
   // destination region must be at least as large in both dimensions than the

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -42,15 +42,30 @@ class PixelBufferWriter : public Document::PixelWriter {
   // Constructs a BufferPixel writer with the given settings. buffer_width
   // gives the number of pixels in a row in the buffer. buffer is the target
   // buffer.
-  explicit PixelBufferWriter(PixelBuffer* buffer) : _buffer(buffer) {}
+  PixelBufferWriter(PixelBuffer* buffer, Viewer::ColorMode color_mode)
+      : _buffer(buffer), _color_mode(color_mode) {}
   // See PixelWriter.
   void Write(int x, int y, uint8_t r, uint8_t g, uint8_t b) override {
+    switch (_color_mode) {
+      case Viewer::ColorMode::NORMAL:
+        break;
+      case Viewer::ColorMode::INVERT_COLORS:
+        r = UINT8_MAX - r;
+        g = UINT8_MAX - g;
+        b = UINT8_MAX - b;
+        break;
+      default:
+        fprintf(stderr, "Unknown color mode %d", _color_mode);
+        abort();
+    }
     _buffer->WritePixel(x, y, r, g, b);
   }
 
  private:
   // The destination buffer.
   PixelBuffer* _buffer;
+  // The current color mode.
+  Viewer::ColorMode _color_mode;
 };
 
 }  // namespace
@@ -90,8 +105,8 @@ void Viewer::Render() {
   zoom = std::max(MIN_ZOOM, std::min(MAX_ZOOM, zoom));
 
   // 2. Render page to buffer.
-  PixelBuffer* buffer =
-      _render_cache.Get(RenderCacheKey(page, zoom, _state.Rotation));
+  PixelBuffer* buffer = _render_cache.Get(
+      RenderCacheKey(page, zoom, _state.Rotation, _state.ColorMode));
 
   // 3. Compute the area actually visible on screen.
   const PixelBuffer::Size &screen_size = _fb->GetSize(),
@@ -123,7 +138,8 @@ void Viewer::Render() {
 
   // 6. Preload.
   if ((_render_cache.GetSize() > 1) && (page < _doc->GetNumPages() - 1)) {
-    _render_cache.Prepare(RenderCacheKey(page + 1, zoom, _state.Rotation));
+    _render_cache.Prepare(
+        RenderCacheKey(page + 1, zoom, _state.Rotation, _state.ColorMode));
   }
 }
 
@@ -139,6 +155,7 @@ void Viewer::GetState(Viewer::State* state) const {
   state->PageHeight = _state.PageHeight;
   state->ScreenWidth = _state.ScreenWidth;
   state->ScreenHeight = _state.ScreenHeight;
+  state->ColorMode = _state.ColorMode;
 }
 
 void Viewer::SetState(const State& state) { _state = state; }
@@ -156,6 +173,9 @@ bool Viewer::RenderCacheKey::operator<(
   if (fabs(Zoom / other.Zoom - 1.0f) >= 0.1f) {
     return Zoom < other.Zoom;
   }
+  if (ColorMode != other.ColorMode) {
+    return ColorMode < other.ColorMode;
+  }
   return false;
 }
 
@@ -170,7 +190,7 @@ PixelBuffer* Viewer::RenderCache::Load(const RenderCacheKey& key) {
 
   PixelBuffer* buffer = _parent->_fb->NewPixelBuffer(
       PixelBuffer::Size(page_size.Width, page_size.Height));
-  PixelBufferWriter writer(buffer);
+  PixelBufferWriter writer(buffer, key.ColorMode);
   _parent->_doc->Render(&writer, key.Page, key.Zoom, key.Rotation);
 
   return buffer;

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -39,7 +39,7 @@ namespace {
 // stored as three consecutive ints representing the r, g, and b values.
 class PixelBufferWriter : public Document::PixelWriter {
  public:
-  // Constructs a BufferPixel writer with the given settings. buffer_width
+  // Constructs a PixelBuffer writer with the given settings. buffer_width
   // gives the number of pixels in a row in the buffer. buffer is the target
   // buffer.
   PixelBufferWriter(PixelBuffer* buffer, Viewer::ColorMode color_mode)
@@ -49,10 +49,21 @@ class PixelBufferWriter : public Document::PixelWriter {
     switch (_color_mode) {
       case Viewer::ColorMode::NORMAL:
         break;
-      case Viewer::ColorMode::INVERT_COLORS:
+      case Viewer::ColorMode::INVERTED:
         r = UINT8_MAX - r;
         g = UINT8_MAX - g;
         b = UINT8_MAX - b;
+        break;
+      case Viewer::ColorMode::SEPIA:
+        r = ::std::min(
+            static_cast<uint32_t>(r * 0.393f + g * 0.769f + b * 0.189f),
+            static_cast<uint32_t>(UINT8_MAX));
+        g = ::std::min(
+            static_cast<uint32_t>(r * 0.349f + g * 0.686f + b * 0.168f),
+            static_cast<uint32_t>(UINT8_MAX));
+        b = ::std::min(
+            static_cast<uint32_t>(r * 0.272f + g * 0.534f + b * 0.131f),
+            static_cast<uint32_t>(UINT8_MAX));
         break;
       default:
         fprintf(stderr, "Unknown color mode %d", _color_mode);

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -20,10 +20,13 @@
 // Document page on top of Framebuffer.
 
 #include "viewer.hpp"
+
 #include <unistd.h>
+
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+
 #include "document.hpp"
 #include "framebuffer.hpp"
 
@@ -41,7 +44,7 @@ class PixelBufferWriter : public Document::PixelWriter {
   // buffer.
   explicit PixelBufferWriter(PixelBuffer* buffer) : _buffer(buffer) {}
   // See PixelWriter.
-  void Write(int x, int y, int r, int g, int b) override {
+  void Write(int x, int y, uint8_t r, uint8_t g, uint8_t b) override {
     _buffer->WritePixel(x, y, r, g, b);
   }
 

--- a/src/viewer.hpp
+++ b/src/viewer.hpp
@@ -41,6 +41,12 @@ class Viewer {
     ZOOM_TO_WIDTH = -4,
   };
 
+  // Color mode.
+  enum ColorMode {
+    NORMAL,
+    INVERT_COLORS,
+  };
+
   // Maximum zoom ratio.
   static const float MAX_ZOOM;
   // Minimum zoom ratio.
@@ -80,6 +86,9 @@ class Viewer {
     // Render() itself.
     int ScreenHeight;
 
+    // Current color mode.
+    enum ColorMode ColorMode;
+
     State(
         int page = 0, float zoom = ZOOM_TO_WIDTH, int rotation = 0,
         int x_offset = 0, int y_offset = 0)
@@ -87,7 +96,8 @@ class Viewer {
           Zoom(zoom),
           Rotation(rotation),
           XOffset(x_offset),
-          YOffset(y_offset) {}
+          YOffset(y_offset),
+          ColorMode(NORMAL) {}
   };
 
   // Constructs a new Viewer object. Does not take ownership of the document or
@@ -124,9 +134,12 @@ class Viewer {
     float Zoom;
     // Rotation in clockwise degrees.
     int Rotation;
+    // Color mode.
+    enum ColorMode ColorMode;
 
-    RenderCacheKey(int page, float zoom, int rotation)
-        : Page(page), Zoom(zoom), Rotation(rotation) {}
+    RenderCacheKey(
+        int page, float zoom, int rotation, enum ColorMode color_mode)
+        : Page(page), Zoom(zoom), Rotation(rotation), ColorMode(color_mode) {}
 
     // This is required as this class will be inserted into a map.
     bool operator<(const RenderCacheKey& other) const;

--- a/src/viewer.hpp
+++ b/src/viewer.hpp
@@ -44,7 +44,8 @@ class Viewer {
   // Color mode.
   enum ColorMode {
     NORMAL,
-    INVERT_COLORS,
+    INVERTED,
+    SEPIA,
   };
 
   // Maximum zoom ratio.


### PR DESCRIPTION
Fixes #34 

This PR implements an inverted color ("dark") mode (toggled by Shift-I) and a sepia color mode (toggled by Shift-S). The initial color mode can be specified on the command line with `-c` / `--color_mode`.