### PR TITLE
Migrate to MuPDF Fitz API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /build/
 /upload/
 /.ccls-cache/
+/compile_commands.json
 /.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,12 @@ set(
   PACKAGE_FORMAT
   "DEB"
   CACHE STRING
-  "CPack package generator(s) to enable.")
+  "CPack package generator to enable.")
+set(
+  LIBJPEG_PACKAGE_NAME
+  "libjpeg62-turbo"
+  CACHE STRING
+  "The name of the libjpeg package to include as a dependency in the generated package.")
 set(
   PACKAGE_FILE_PREFIX
   "jfbview"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,16 @@ set(
   CACHE STRING
   "CPack package file name prefix.")
 option(BUILD_TESTING "Build unit tests." OFF)
+option(
+  ENABLE_LEGACY_PDF_IMPL
+  "If ON, enables legacy PDF document implementation based on low-level MuPDF APIs."
+  OFF
+)
+option(
+  ENABLE_LEGACY_IMAGE_IMPL
+  "If ON, enables legacy image document implementation based on Imlib2."
+  OFF
+)
 
 # Third-party code in vendor.
 # ---------------------------

--- a/doc/README.md
+++ b/doc/README.md
@@ -58,8 +58,6 @@ To build from source, fetch the source code along with transitive dependencies a
 
   - [NCURSES](https://invisible-island.net/ncurses/ncurses.html)
 
-  - [Imlib2](https://docs.enlightenment.org/api/imlib2/html/index.html)
-
   - [libjpeg](http://libjpeg.sourceforge.net/) or [libjpeg-turbo](https://libjpeg-turbo.org/)
 
 Build-time dependencies:
@@ -90,12 +88,6 @@ cd build
 make
 make install
 ```
-
-It is also possible to build a variant of jfbview without support for images
-and without dependency on Imlib2. To build this variant, specify the CMake flag
-`-DENABLE_IMAGE_SUPPORT=OFF`. For backwards compatibility, this will also
-enable an alias for `jfbview` called `jfbpdf`.
-
 
 DOCUMENTATION
 -------------

--- a/doc/jfbview.1
+++ b/doc/jfbview.1
@@ -39,14 +39,6 @@ Start in inverted color mode.
 \fB--color_mode=\fRsepia, \fB-c\fR sepia
 Start in sepia color mode.
 .TP
-\fB--format=image\fR
-Forces the program to treat the input file as an image.
-.TP
-\fB--format=pdf\fR
-Forces the program to treat the input file as a PDF. By default, the file format
-is detected based on its extension. If the file does not have a ".pdf" (case is
-ignored) extension, this will force jfbview to load it as a PDF.
-.TP
 \fB--cache_size=\fRn
 Selects the number of pages to cache. jfbview has a in-memory cache of pages
 rendered at a particular zoom and rotation setting. However, you may wish to

--- a/doc/jfbview.1.html
+++ b/doc/jfbview.1.html
@@ -48,22 +48,13 @@
        <B>--color_mode=</B>sepia, <B>-c</B> sepia
               Start in sepia color mode.
 
-       <B>--format=image</B>
-              Forces the program to treat the input file as an image.
-
-       <B>--format=pdf</B>
-              Forces the program to treat the input file as a PDF. By default,
-              the file format is detected based on its extension. If the  file
-              does  not  have  a ".pdf" (case is ignored) extension, this will
-              force jfbview to load it as a PDF.
-
        <B>--cache_size=</B>n
-              Selects the number of pages to cache. jfbview  has  a  in-memory
-              cache  of  pages rendered at a particular zoom and rotation set‐
-              ting. However, you may wish to adjust the  cache  size  down  if
-              this  cache is consuming too much memory, or you may wish to ad‐
+              Selects  the  number  of pages to cache. jfbview has a in-memory
+              cache of pages rendered at a particular zoom and  rotation  set‐
+              ting.  However,  you  may  wish to adjust the cache size down if
+              this cache is consuming too much memory, or you may wish to  ad‐
               just the cache size up for increased performance. If you have an
-              older  machine  with limited RAM you may want to set it close to
+              older machine with limited RAM you may want to set it  close  to
               zero.
 
 <B>KEY</B> <B>BINDINGS</B> <B>-</B> <B>MAIN</B> <B>VIEW</B>
@@ -165,7 +156,7 @@
        <B>Tab</B>/<B>/</B>  Go to search text.
 
 <B>BUGS</B>
-       Please submit bugs reports  and  any  suggestions  for  improvement  at
+       Please  submit  bugs  reports  and  any  suggestions for improvement at
        https://github.com/jichu4n/jfbview/issues.
 
 <B>AUTHOR</B>

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Chuan Ji <chuan@jichu4n.com>")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/jichu4n/jfbview")
 set(
   CPACK_DEBIAN_PACKAGE_DEPENDS
-  "libncurses5, libncursesw5, libimlib2"
+  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}"
 )
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
@@ -27,7 +27,7 @@ set(CPACK_RPM_PACKAGE_GROUP "Applications/Text")
 set(CPACK_RPM_PACKAGE_URL "https://github.com/jichu4n/jfbview")
 set(
   CPACK_RPM_PACKAGE_REQUIRES
-  "ncurses-libs, imlib2"
+  "ncurses-libs, ${LIBJPEG_PACKAGE_NAME}"
 )
 # This is needed to prevent a "conflicts with file from package
 # filesystem-XXXX" error.

--- a/packaging/build-package-deb.sh
+++ b/packaging/build-package-deb.sh
@@ -16,7 +16,7 @@ function install_build_deps() {
   $sudo apt-get -qq update
   $sudo apt-get -qq install -y \
     build-essential cmake file \
-    libncurses-dev libncursesw5-dev libimlib2-dev \
+    libncurses-dev libncursesw5-dev libjpeg-dev \
     > /dev/null  # -qq doesn't actually silence apt-get install.
 }
 

--- a/packaging/build-package-deb.sh
+++ b/packaging/build-package-deb.sh
@@ -11,12 +11,20 @@ else
   sudo='sudo'
 fi
 
+if grep -qi ubuntu /etc/os-release; then
+  libjpeg=libjpeg8
+  libjpeg_dev=libjpeg8-dev
+else
+  libjpeg=libjpeg62-turbo
+  libjpeg_dev=libjpeg62-turbo-dev
+fi
+
 function install_build_deps() {
   export DEBIAN_FRONTEND=noninteractive
   $sudo apt-get -qq update
   $sudo apt-get -qq install -y \
     build-essential cmake file \
-    libncurses-dev libncursesw5-dev libjpeg-dev \
+    libncurses-dev libncursesw5-dev ${libjpeg_dev} \
     > /dev/null  # -qq doesn't actually silence apt-get install.
 }
 
@@ -25,6 +33,7 @@ function build_package() {
   mkdir -p build upload
   cmake -H. -Bbuild \
     -DPACKAGE_FORMAT=DEB \
+    -DLIBJPEG_PACKAGE_NAME=${libjpeg} \
     -DPACKAGE_FILE_PREFIX="$package_file_prefix" \
     -DBUILD_TESTING=OFF \
     -DCMAKE_BUILD_TYPE=Release

--- a/packaging/build-package-rpm.sh
+++ b/packaging/build-package-rpm.sh
@@ -16,7 +16,7 @@ function install_build_deps() {
   $sudo yum install -y -q \
     cmake make gcc-c++ rpm-build \
     ncurses-devel \
-    libjpeg-devel
+    libjpeg-turbo-devel
 }
 
 function build_package() {
@@ -24,6 +24,7 @@ function build_package() {
   mkdir -p build upload
   cmake -H. -Bbuild \
     -DPACKAGE_FORMAT=RPM \
+    -DLIBJPEG_PACKAGE_NAME=libjpeg-turbo \
     -DPACKAGE_FILE_PREFIX="$package_file_prefix" \
     -DBUILD_TESTING=OFF \
     -DCMAKE_BUILD_TYPE=Release

--- a/packaging/build-package-rpm.sh
+++ b/packaging/build-package-rpm.sh
@@ -15,7 +15,7 @@ function install_build_deps() {
   $sudo yum install -y -q epel-release
   $sudo yum install -y -q \
     cmake make gcc-c++ rpm-build \
-    ncurses-devel imlib2-devel \
+    ncurses-devel \
     libjpeg-devel
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(
   pdf_document.cpp
   image_document.cpp
   fitz_document.cpp
+  fitz_utils.cpp
   string_utils.cpp
   multithreading.cpp
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,14 +18,19 @@ set(CURSES_NEED_NCURSES ON)
 find_package(Curses REQUIRED)
 include_directories(${CURSES_INCLUDE_DIRS})
 
-if(ENABLE_IMAGE_SUPPORT)
-  find_package(Imlib2 REQUIRED)
-  include_directories(${IMLIB2_INCLUDE_DIR})
+if(ENABLE_LEGACY_IMAGE_IMPL)
+  if(ENABLE_IMAGE_SUPPORT)
+    find_package(Imlib2 REQUIRED)
+    include_directories(${IMLIB2_INCLUDE_DIR})
+  else()
+    add_definitions(
+      -DJFBVIEW_NO_IMLIB2
+    )
+    set(IMLIB2_LIBRARIES)
+  endif()
+  set(imlib2_libs ${IMLIB2_LIBRARIES})
 else()
-  add_definitions(
-    -DJFBVIEW_NO_IMLIB2
-  )
-  set(IMLIB2_LIBRARIES)
+  set(imlib2_libs)
 endif()
 
 # Build settings.
@@ -35,6 +40,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_definitions(
   -DJFBVIEW_VERSION=\"${PROJECT_VERSION}\"
 )
+if(ENABLE_LEGACY_IMAGE_IMPL)
+  add_definitions(
+    -DJFBVIEW_ENABLE_LEGACY_IMAGE_IMPL
+  )
+endif()
+if(ENABLE_LEGACY_PDF_IMPL)
+  add_definitions(
+    -DJFBVIEW_ENABLE_LEGACY_PDF_IMPL
+  )
+endif()
 
 # Detect MuPDF version.
 # ---------------------
@@ -66,10 +81,10 @@ add_library(
   jfbview_document
   STATIC
   document.cpp
-  pdf_document.cpp
-  image_document.cpp
   fitz_document.cpp
   fitz_utils.cpp
+  image_document.cpp
+  pdf_document.cpp
   string_utils.cpp
   multithreading.cpp
 )
@@ -77,12 +92,14 @@ target_link_libraries(
   jfbview_document
   Threads::Threads
   ${vendor_mupdf_libs}
-  ${IMLIB2_LIBRARIES}
+  ${imlib2_libs}
 )
-add_dependencies(
-  jfbview_document
-  detected_mupdf_version.hpp
-)
+if(ENABLE_LEGACY_PDF_IMPL)
+  add_dependencies(
+    jfbview_document
+    detected_mupdf_version.hpp
+  )
+endif()
 
 # Common viewer code shared by jfbview and jfbpdf.
 # ------------------------------------------------
@@ -131,16 +148,18 @@ install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/jpdfcat DESTINATION bin)
 
 # jfbpdf
 # ------
-if(NOT ENABLE_IMAGE_SUPPORT)
-  add_executable(jfbpdf ${jfbview_sources})
-  target_compile_definitions(
-    jfbpdf
-    PRIVATE
-    JFBVIEW_NO_IMLIB2
-    JFBVIEW_PROGRAM_NAME=\"JFBPDF\"
-    JFBVIEW_BINARY_NAME=\"jfbpdf\"
-  )
-  target_link_libraries(jfbpdf jfbview_document_viewer)
-  install(TARGETS jfbpdf DESTINATION bin)
+if(ENABLE_LEGACY_IMAGE_IMPL)
+  if(NOT ENABLE_IMAGE_SUPPORT)
+    add_executable(jfbpdf ${jfbview_sources})
+    target_compile_definitions(
+      jfbpdf
+      PRIVATE
+      JFBVIEW_NO_IMLIB2
+      JFBVIEW_PROGRAM_NAME=\"JFBPDF\"
+      JFBVIEW_BINARY_NAME=\"jfbpdf\"
+    )
+    target_link_libraries(jfbpdf jfbview_document_viewer)
+    install(TARGETS jfbpdf DESTINATION bin)
+  endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(
   document.cpp
   pdf_document.cpp
   image_document.cpp
+  fitz_document.cpp
   string_utils.cpp
   multithreading.cpp
 )

--- a/src/fitz_document.cpp
+++ b/src/fitz_document.cpp
@@ -1,10 +1,78 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *                                                                           *
+ *  Copyright (C) 2020-2020 Chuan Ji                                         *
+ *                                                                           *
+ *  Licensed under the Apache License, Version 2.0 (the "License");          *
+ *  you may not use this file except in compliance with the License.         *
+ *  You may obtain a copy of the License at                                  *
+ *                                                                           *
+ *   http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                           *
+ *  Unless required by applicable law or agreed to in writing, software      *
+ *  distributed under the License is distributed on an "AS IS" BASIS,        *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *  See the License for the specific language governing permissions and      *
+ *  limitations under the License.                                           *
+ *                                                                           *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+// This file defines FitzDocument, an implementation of the Document
+// abstraction using Fitz.
+
 #include "fitz_document.hpp"
 
 #include <cassert>
 
+#include "fitz_utils.hpp"
+#include "multithreading.hpp"
+
+namespace {
+
+fz_irect GetPageBoundingBox(
+    fz_context* ctx, std::mutex* fz_mutex, fz_page* page_struct,
+    const fz_matrix& m) {
+  assert(page_struct != nullptr);
+  std::lock_guard<std::mutex> lock(*fz_mutex);
+  return fz_round_rect(fz_transform_rect(fz_bound_page(ctx, page_struct), m));
+}
+
+class FitzDocumentPageCache : public Cache<int, fz_page*> {
+ public:
+  FitzDocumentPageCache(
+      fz_context* fz_ctx, fz_document* fz_doc, std::mutex* fz_mutex,
+      int page_cache_size)
+      : Cache<int, fz_page*>(page_cache_size),
+        _fz_ctx(fz_ctx),
+        _fz_doc(fz_doc),
+        _fz_mutex(fz_mutex) {}
+  virtual ~FitzDocumentPageCache() { Clear(); }
+
+ protected:
+  fz_page* Load(const int& page) override {
+    std::lock_guard<std::mutex> lock(*_fz_mutex);
+    return fz_load_page(_fz_ctx, _fz_doc, page);
+  }
+
+  void Discard(const int& page, fz_page* const& page_struct) override {
+    std::lock_guard<std::mutex> lock(*_fz_mutex);
+    fz_drop_page(_fz_ctx, page_struct);
+  }
+
+ private:
+  // Pointer to parent FitzDocument's MuPDF structures. Does NOT have ownerhip.
+  fz_context* _fz_ctx;
+  fz_document* _fz_doc;
+  // Pointer to parent FitzDocument's mutex guarding MuPDF structures. Does NOT
+  // have ownership.
+  std::mutex* _fz_mutex;
+};
+
+}  // namespace
+
 Document* FitzDocument::Open(
-    const std::string& path, const std::string* password) {
+    const std::string& path, const std::string* password, int page_cache_size) {
   fz_context* fz_ctx = fz_new_context(nullptr, nullptr, FZ_STORE_DEFAULT);
+  fz_register_document_handlers(fz_ctx);
   // Disable warning messages in the console.
   fz_set_warning_callback(
       fz_ctx, [](void* user, const char* message) {}, nullptr);
@@ -42,16 +110,25 @@ Document* FitzDocument::Open(
     return nullptr;
   }
 
-  return new FitzDocument(fz_ctx, fz_doc);
+  return new FitzDocument(fz_ctx, fz_doc, page_cache_size);
 }
 
-FitzDocument::FitzDocument(fz_context* fz_ctx, fz_document* fz_doc)
-    : _fz_ctx(fz_ctx), _fz_doc(fz_doc) {
+FitzDocument::FitzDocument(
+    fz_context* fz_ctx, fz_document* fz_doc, int page_cache_size)
+    : _fz_ctx(fz_ctx),
+      _fz_doc(fz_doc),
+      _page_cache(new FitzDocumentPageCache(
+          fz_ctx, fz_doc, &_fz_mutex, page_cache_size)) {
   assert(_fz_ctx != nullptr);
   assert(_fz_doc != nullptr);
 }
 
 FitzDocument::~FitzDocument() {
+  // Must destroy page cache explicitly first, since destroying cached pages
+  // involves clearing MuPDF state, which requires document structures
+  // (_fz_doc, _fz_ctx) to still exist.
+  _page_cache.reset();
+
   std::lock_guard<std::mutex> lock(_fz_mutex);
   fz_drop_document(_fz_ctx, _fz_doc);
   fz_drop_context(_fz_ctx);
@@ -64,10 +141,60 @@ int FitzDocument::GetNumPages() {
 
 const Document::PageSize FitzDocument::GetPageSize(
     int page, float zoom, int rotation) {
-  return PageSize(0, 0);
+  assert((page >= 0) && (page < GetNumPages()));
+  const fz_irect& bbox = GetPageBoundingBox(
+      _fz_ctx, &_fz_mutex, GetPage(page),
+      ComputeTransformMatrix(zoom, rotation));
+  return PageSize(bbox.x1 - bbox.x0, bbox.y1 - bbox.y0);
 }
 
-void Document::Render(
+void FitzDocument::Render(
     Document::PixelWriter* pw, int page, float zoom, int rotation) {
-  // no-op
+  assert((page >= 0) && (page < GetNumPages()));
+
+  // 1. Init MuPDF structures.
+  const fz_matrix& m = ComputeTransformMatrix(zoom, rotation);
+  fz_page* page_struct = GetPage(page);
+  const fz_irect& bbox =
+      GetPageBoundingBox(_fz_ctx, &_fz_mutex, page_struct, m);
+  std::lock_guard<std::mutex> lock(_fz_mutex);
+  fz_pixmap* pixmap = fz_new_pixmap_with_bbox(
+      _fz_ctx, fz_device_rgb(_fz_ctx), bbox, nullptr, 1);
+  fz_device* dev = fz_new_draw_device(_fz_ctx, fz_identity, pixmap);
+
+  // 2. Render page.
+  fz_clear_pixmap_with_value(_fz_ctx, pixmap, 0xff);
+  fz_run_page(_fz_ctx, page_struct, dev, m, nullptr);
+
+  // 3. Write pixmap to buffer. The page is vertically divided into n equal
+  // stripes, each copied to pw by one thread.
+  assert(fz_pixmap_components(_fz_ctx, pixmap) == 4);
+  uint8_t* buffer =
+      reinterpret_cast<uint8_t*>(fz_pixmap_samples(_fz_ctx, pixmap));
+  const int num_cols = fz_pixmap_width(_fz_ctx, pixmap);
+  const int num_rows = fz_pixmap_height(_fz_ctx, pixmap);
+  ExecuteInParallel([=](int num_threads, int i) {
+    const int num_rows_per_thread = num_rows / num_threads;
+    const int y_begin = i * num_rows_per_thread;
+    const int y_end =
+        (i == num_threads - 1) ? num_rows : (i + 1) * num_rows_per_thread;
+    uint8_t* p = buffer + y_begin * num_cols * 4;
+    for (int y = y_begin; y < y_end; ++y) {
+      for (int x = 0; x < num_cols; ++x) {
+        pw->Write(x, y, p[0], p[1], p[2]);
+        p += 4;
+      }
+    }
+  });
+
+  // 4. Clean up.
+  fz_close_device(_fz_ctx, dev);
+  fz_drop_device(_fz_ctx, dev);
+  fz_drop_pixmap(_fz_ctx, pixmap);
 }
+
+fz_page* FitzDocument::GetPage(int page) {
+  assert((page >= 0) && (page < GetNumPages()));
+  return _page_cache->Get(page);
+}
+

--- a/src/fitz_document.cpp
+++ b/src/fitz_document.cpp
@@ -33,6 +33,7 @@ fz_irect GetPageBoundingBox(
     const fz_matrix& m) {
   assert(page_struct != nullptr);
   std::lock_guard<std::mutex> lock(*fz_mutex);
+  const auto r = fz_bound_page(ctx, page_struct);
   return fz_round_rect(fz_transform_rect(fz_bound_page(ctx, page_struct), m));
 }
 
@@ -157,6 +158,7 @@ void FitzDocument::Render(
   fz_page* page_struct = GetPage(page);
   const fz_irect& bbox =
       GetPageBoundingBox(_fz_ctx, &_fz_mutex, page_struct, m);
+
   std::lock_guard<std::mutex> lock(_fz_mutex);
   fz_pixmap* pixmap = fz_new_pixmap_with_bbox(
       _fz_ctx, fz_device_rgb(_fz_ctx), bbox, nullptr, 1);

--- a/src/fitz_document.cpp
+++ b/src/fitz_document.cpp
@@ -1,0 +1,73 @@
+#include "fitz_document.hpp"
+
+#include <cassert>
+
+Document* FitzDocument::Open(
+    const std::string& path, const std::string* password) {
+  fz_context* fz_ctx = fz_new_context(nullptr, nullptr, FZ_STORE_DEFAULT);
+  // Disable warning messages in the console.
+  fz_set_warning_callback(
+      fz_ctx, [](void* user, const char* message) {}, nullptr);
+
+  fz_document* fz_doc = nullptr;
+  fz_try(fz_ctx) {
+    fz_doc = fz_open_document(fz_ctx, path.c_str());
+    if ((fz_doc == nullptr) || (!fz_count_pages(fz_ctx, fz_doc))) {
+      fz_throw(
+          fz_ctx, FZ_ERROR_GENERIC,
+          const_cast<char*>("Cannot open document \"%s\""), path.c_str());
+    }
+    if (fz_needs_password(fz_ctx, fz_doc)) {
+      if (password == nullptr) {
+        fz_throw(
+            fz_ctx, FZ_ERROR_GENERIC,
+            const_cast<char*>(
+                "Document \"%s\" is password protected.\n"
+                "Please provide the password with \"-P <password>\"."),
+            path.c_str());
+      }
+      if (!fz_authenticate_password(fz_ctx, fz_doc, password->c_str())) {
+        fz_throw(
+            fz_ctx, FZ_ERROR_GENERIC,
+            const_cast<char*>("Incorrect password for document \"%s\"."),
+            path.c_str());
+      }
+    }
+  }
+  fz_catch(fz_ctx) {
+    if (fz_doc != nullptr) {
+      fz_drop_document(fz_ctx, fz_doc);
+    }
+    fz_drop_context(fz_ctx);
+    return nullptr;
+  }
+
+  return new FitzDocument(fz_ctx, fz_doc);
+}
+
+FitzDocument::FitzDocument(fz_context* fz_ctx, fz_document* fz_doc)
+    : _fz_ctx(fz_ctx), _fz_doc(fz_doc) {
+  assert(_fz_ctx != nullptr);
+  assert(_fz_doc != nullptr);
+}
+
+FitzDocument::~FitzDocument() {
+  std::lock_guard<std::mutex> lock(_fz_mutex);
+  fz_drop_document(_fz_ctx, _fz_doc);
+  fz_drop_context(_fz_ctx);
+}
+
+int FitzDocument::GetNumPages() {
+  std::lock_guard<std::mutex> lock(_fz_mutex);
+  return fz_count_pages(_fz_ctx, _fz_doc);
+}
+
+const Document::PageSize FitzDocument::GetPageSize(
+    int page, float zoom, int rotation) {
+  return PageSize(0, 0);
+}
+
+void Document::Render(
+    Document::PixelWriter* pw, int page, float zoom, int rotation) {
+  // no-op
+}

--- a/src/fitz_document.cpp
+++ b/src/fitz_document.cpp
@@ -158,7 +158,7 @@ int FitzDocument::Lookup(const OutlineItem* item) {
 std::string FitzDocument::GetPageText(int page, int line_sep) {
   std::lock_guard<std::recursive_mutex> lock(_fz_mutex);
   FitzPageScopedPtr page_ptr(_fz_ctx, fz_load_page(_fz_ctx, _fz_doc, page));
-  return ::GetPageText(_fz_ctx, page_ptr.get(), ' ');
+  return ::GetPageText(_fz_ctx, page_ptr.get(), line_sep);
 }
 
 std::vector<Document::SearchHit> FitzDocument::SearchOnPage(

--- a/src/fitz_document.hpp
+++ b/src/fitz_document.hpp
@@ -27,26 +27,18 @@
 #include <string>
 #include <vector>
 
-#include "cache.hpp"
 #include "document.hpp"
-extern "C" {
-#include "mupdf/fitz.h"
-}
+#include "fitz_utils.hpp"
 
 // Document implementation using Fitz.
 class FitzDocument : public Document {
  public:
-  // Default size of page cache.
-  enum { DEFAULT_PAGE_CACHE_SIZE = 5 };
-
   virtual ~FitzDocument();
   // Factory method to construct an instance of FitzDocument. path gives the
   // path to a file. password is the password to use to unlock the document;
   // specify nullptr if no password was provided. Does not take ownership of
   // password. Returns nullptr if the file cannot be opened.
-  static Document* Open(
-      const std::string& path, const std::string* password,
-      int page_cache_size = DEFAULT_PAGE_CACHE_SIZE);
+  static Document* Open(const std::string& path, const std::string* password);
   // See Document.
   int GetNumPages() override;
   // See Document.
@@ -69,20 +61,12 @@ class FitzDocument : public Document {
   fz_document* _fz_doc;
   // Mutex guarding MuPDF structures.
   std::recursive_mutex _fz_mutex;
-  // Cache for loaded pages.
-  std::unique_ptr<Cache<int, fz_page*>> _page_cache;
 
   // We disallow the constructor; use the factory method Open() instead.
-  FitzDocument(
-      fz_context* _fz_context, fz_document* fz_document, int page_cache_size);
+  FitzDocument(fz_context* _fz_context, fz_document* fz_document);
   // We disallow copying because we store lots of heap allocated state.
   explicit FitzDocument(const FitzDocument& other);
   FitzDocument& operator=(const FitzDocument& other);
-
-  // Wrapper around fz_load_page that implements caching. If _page_cache_size
-  // is reached, throw out the oldest page. Will also attempt to load the pages
-  // before and after specified page. Returns the loaded page.
-  fz_page* GetPage(int page);
 };
 
 #endif

--- a/src/fitz_document.hpp
+++ b/src/fitz_document.hpp
@@ -1,0 +1,76 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *                                                                           *
+ *  Copyright (C) 2012-2020 Chuan Ji                                         *
+ *                                                                           *
+ *  Licensed under the Apache License, Version 2.0 (the "License");          *
+ *  you may not use this file except in compliance with the License.         *
+ *  You may obtain a copy of the License at                                  *
+ *                                                                           *
+ *   http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                           *
+ *  Unless required by applicable law or agreed to in writing, software      *
+ *  distributed under the License is distributed on an "AS IS" BASIS,        *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *  See the License for the specific language governing permissions and      *
+ *  limitations under the License.                                           *
+ *                                                                           *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+// This file declares FitzDocument, an implementation of the Document
+// abstraction using Fitz.
+
+#ifndef FITZ_DOCUMENT_HPP
+#define FITZ_DOCUMENT_HPP
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "document.hpp"
+extern "C" {
+#include "mupdf/fitz.h"
+}
+
+// Document implementation using Fitz.
+class FitzDocument : public Document {
+ public:
+  virtual ~FitzDocument();
+  // Factory method to construct an instance of FitzDocument. path gives the
+  // path to a file. password is the password to use to unlock the document;
+  // specify nullptr if no password was provided. Does not take ownership of
+  // password. Returns nullptr if the file cannot be opened.
+  static Document* Open(const std::string& path, const std::string* password);
+  // See Document.
+  int GetNumPages() override;
+  // See Document.
+  const PageSize GetPageSize(int page, float zoom, int rotation) override;
+  // See Document. Thread-safe.
+  void Render(PixelWriter* pw, int page, float zoom, int rotation) override;
+  // See Document.
+  const OutlineItem* GetOutline() override { return nullptr; }
+  // See Document.
+  int Lookup(const OutlineItem* item) override { return -1; }
+
+ protected:
+  // See Document.
+  std::vector<SearchHit> SearchOnPage(
+      const std::string& search_string, int page, int context_length) override {
+    return std::vector<SearchHit>();
+  }
+
+ private:
+  // MuPDF structures.
+  fz_context* _fz_ctx;
+  fz_document* _fz_doc;
+  // Mutex guarding MuPDF structures.
+  std::mutex _fz_mutex;
+
+  // We disallow the constructor; use the factory method Open() instead.
+  FitzDocument(fz_context* _fz_context, fz_document* fz_document);
+  // We disallow copying because we store lots of heap allocated state.
+  explicit FitzDocument(const FitzDocument& other);
+  FitzDocument& operator=(const FitzDocument& other);
+};
+
+#endif

--- a/src/fitz_document.hpp
+++ b/src/fitz_document.hpp
@@ -38,7 +38,8 @@ class FitzDocument : public Document {
   // path to a file. password is the password to use to unlock the document;
   // specify nullptr if no password was provided. Does not take ownership of
   // password. Returns nullptr if the file cannot be opened.
-  static Document* Open(const std::string& path, const std::string* password);
+  static FitzDocument* Open(
+      const std::string& path, const std::string* password);
   // See Document.
   int GetNumPages() override;
   // See Document.
@@ -49,6 +50,8 @@ class FitzDocument : public Document {
   const OutlineItem* GetOutline() override;
   // See Document.
   int Lookup(const OutlineItem* item) override;
+  // Returns the text content of a page, using line_sep to separate lines.
+  std::string GetPageText(int page, int line_sep = '\n');
 
  protected:
   // See Document.

--- a/src/fitz_document.hpp
+++ b/src/fitz_document.hpp
@@ -54,23 +54,21 @@ class FitzDocument : public Document {
   // See Document. Thread-safe.
   void Render(PixelWriter* pw, int page, float zoom, int rotation) override;
   // See Document.
-  const OutlineItem* GetOutline() override { return nullptr; }
+  const OutlineItem* GetOutline() override;
   // See Document.
-  int Lookup(const OutlineItem* item) override { return -1; }
+  int Lookup(const OutlineItem* item) override;
 
  protected:
   // See Document.
   std::vector<SearchHit> SearchOnPage(
-      const std::string& search_string, int page, int context_length) override {
-    return std::vector<SearchHit>();
-  }
+      const std::string& search_string, int page, int context_length) override;
 
  private:
   // MuPDF structures.
   fz_context* _fz_ctx;
   fz_document* _fz_doc;
   // Mutex guarding MuPDF structures.
-  std::mutex _fz_mutex;
+  std::recursive_mutex _fz_mutex;
   // Cache for loaded pages.
   std::unique_ptr<Cache<int, fz_page*>> _page_cache;
 

--- a/src/fitz_utils.cpp
+++ b/src/fitz_utils.cpp
@@ -21,8 +21,6 @@
 
 #include "fitz_utils.hpp"
 
-#include "detected_mupdf_version.hpp"
-
 fz_matrix ComputeTransformMatrix(float zoom, int rotation) {
   fz_matrix transformation_matrix, scale_matrix, rotate_matrix;
   scale_matrix = fz_scale(zoom, zoom);

--- a/src/fitz_utils.cpp
+++ b/src/fitz_utils.cpp
@@ -1,0 +1,33 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *                                                                           *
+ *  Copyright (C) 2020-2020 Chuan Ji                                         *
+ *                                                                           *
+ *  Licensed under the Apache License, Version 2.0 (the "License");          *
+ *  you may not use this file except in compliance with the License.         *
+ *  You may obtain a copy of the License at                                  *
+ *                                                                           *
+ *   http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                           *
+ *  Unless required by applicable law or agreed to in writing, software      *
+ *  distributed under the License is distributed on an "AS IS" BASIS,        *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *  See the License for the specific language governing permissions and      *
+ *  limitations under the License.                                           *
+ *                                                                           *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+// This file provides a collection of utilities for working with fitz
+// constructs.
+
+#include "fitz_utils.hpp"
+
+#include "detected_mupdf_version.hpp"
+
+fz_matrix ComputeTransformMatrix(float zoom, int rotation) {
+  fz_matrix transformation_matrix, scale_matrix, rotate_matrix;
+  scale_matrix = fz_scale(zoom, zoom);
+  rotate_matrix = fz_rotate(rotation);
+  transformation_matrix = fz_concat(scale_matrix, rotate_matrix);
+  return transformation_matrix;
+}
+

--- a/src/fitz_utils.cpp
+++ b/src/fitz_utils.cpp
@@ -88,8 +88,8 @@ void FitzOutlineItem::BuildRecursive(
 std::string GetPageText(fz_context* ctx, fz_page* page_struct, int line_sep) {
   // 1. Render page.
   fz_stext_options stext_options = {0};
-  fz_stext_page* text_page =
-      fz_new_stext_page_from_page(ctx, page_struct, &stext_options);
+  FitzStextPageScopedPtr text_page(
+      ctx, fz_new_stext_page_from_page(ctx, page_struct, &stext_options));
 
   // 2. Build text.
   std::string r;
@@ -118,9 +118,6 @@ std::string GetPageText(fz_context* ctx, fz_page* page_struct, int line_sep) {
       }
     }
   }
-
-  // 3. Clean up.
-  fz_drop_stext_page(ctx, text_page);
 
   return r;
 }

--- a/src/fitz_utils.cpp
+++ b/src/fitz_utils.cpp
@@ -21,11 +21,107 @@
 
 #include "fitz_utils.hpp"
 
+#include <cassert>
+
 fz_matrix ComputeTransformMatrix(float zoom, int rotation) {
   fz_matrix transformation_matrix, scale_matrix, rotate_matrix;
   scale_matrix = fz_scale(zoom, zoom);
   rotate_matrix = fz_rotate(rotation);
   transformation_matrix = fz_concat(scale_matrix, rotate_matrix);
   return transformation_matrix;
+}
+
+fz_irect GetPageBoundingBox(
+    fz_context* ctx, fz_page* page_struct, const fz_matrix& m) {
+  assert(page_struct != nullptr);
+  return fz_round_rect(fz_transform_rect(fz_bound_page(ctx, page_struct), m));
+}
+
+namespace {
+
+const char* const DEFAULT_ROOT_OUTLINE_ITEM_TITLE = "TABLE OF CONTENTS";
+
+}  // namespace
+
+FitzOutlineItem::~FitzOutlineItem() {}
+
+FitzOutlineItem::FitzOutlineItem(fz_outline* src) {
+  if (src == nullptr) {
+    _dest_page = -1;
+  } else {
+    _title = src->title;
+    _dest_page = src->page;
+  }
+}
+
+int FitzOutlineItem::GetDestPage() const { return _dest_page; }
+
+FitzOutlineItem* FitzOutlineItem::Build(fz_context* ctx, fz_outline* src) {
+  FitzOutlineItem* root = nullptr;
+  std::vector<std::unique_ptr<OutlineItem>> items;
+  BuildRecursive(src, &items);
+  if (items.empty()) {
+    return nullptr;
+  } else if (items.size() == 1) {
+    root = dynamic_cast<FitzOutlineItem*>(items[0].release());
+  } else {
+    root = new FitzOutlineItem(nullptr);
+    root->_title = DEFAULT_ROOT_OUTLINE_ITEM_TITLE;
+    root->_children.swap(items);
+  }
+  return root;
+}
+
+void FitzOutlineItem::BuildRecursive(
+    fz_outline* src,
+    std::vector<std::unique_ptr<Document::OutlineItem>>* output) {
+  assert(output != nullptr);
+  for (fz_outline* i = src; i != nullptr; i = i->next) {
+    FitzOutlineItem* item = new FitzOutlineItem(i);
+    if (i->down != nullptr) {
+      BuildRecursive(i->down, &(item->_children));
+    }
+    output->push_back(std::unique_ptr<Document::OutlineItem>(item));
+  }
+}
+
+std::string GetPageText(fz_context* ctx, fz_page* page_struct, int line_sep) {
+  // 1. Render page.
+  fz_stext_options stext_options = {0};
+  fz_stext_page* text_page =
+      fz_new_stext_page_from_page(ctx, page_struct, &stext_options);
+
+  // 2. Build text.
+  std::string r;
+  for (fz_stext_block* text_block = text_page->first_block;
+       text_block != nullptr; text_block = text_block->next) {
+    if (text_block->type != FZ_STEXT_BLOCK_TEXT) {
+      continue;
+    }
+    for (fz_stext_line* text_line = text_block->u.t.first_line;
+         text_line != nullptr; text_line = text_line->next) {
+      for (fz_stext_char* text_char = text_line->first_char;
+           text_char != nullptr; text_char = text_char->next) {
+        {
+          const int c = text_char->c;
+          // A single UTF-8 character cannot take more than 4 bytes, but let's
+          // go for 8.
+          char buffer[8];
+          const int num_bytes = fz_runetochar(buffer, c);
+          assert(num_bytes <= static_cast<int>(sizeof(buffer)));
+          buffer[num_bytes] = '\0';
+          r += buffer;
+        }
+      }
+      if (!isspace(r.back())) {
+        r += line_sep;
+      }
+    }
+  }
+
+  // 3. Clean up.
+  fz_drop_stext_page(ctx, text_page);
+
+  return r;
 }
 

--- a/src/fitz_utils.hpp
+++ b/src/fitz_utils.hpp
@@ -26,8 +26,42 @@ extern "C" {
 #include "mupdf/fitz.h"
 }
 
+#include <string>
+
+#include "document.hpp"
+
 // Constructs a transformation matrix from the given parameters.
 extern fz_matrix ComputeTransformMatrix(float zoom, int rotation);
+
+// Returns a bounding box for the given page after applying transformations.
+// NOT thread-safe.
+extern fz_irect GetPageBoundingBox(
+    fz_context* ctx, fz_page* page_struct, const fz_matrix& m);
+
+// An outline item based on fitz's fz_outline.
+class FitzOutlineItem : public Document::OutlineItem {
+ public:
+  virtual ~FitzOutlineItem();
+  // See Document::OutlineItem.
+  int GetDestPage() const;
+  // Factory method to create outline items from a fz_outline. This constructs
+  // the entire outline hierarchy. Does NOT take ownership. NOT thread-safe.
+  static FitzOutlineItem* Build(fz_context* ctx, fz_outline* src);
+
+ private:
+  // Destination page number.
+  int _dest_page;
+  // We disallow constructors; use the factory method Build() instead.
+  explicit FitzOutlineItem(fz_outline* src);
+  // Recursive construction, called by Build().
+  static void BuildRecursive(
+      fz_outline* src, std::vector<std::unique_ptr<OutlineItem>>* output);
+};
+
+// Returns the text content of a page, using line_sep to separate lines. NOT
+// thread-safe.
+extern std::string GetPageText(
+    fz_context* ctx, fz_page* page_struct, int line_sep = '\n');
 
 #endif
 

--- a/src/fitz_utils.hpp
+++ b/src/fitz_utils.hpp
@@ -1,0 +1,33 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *                                                                           *
+ *  Copyright (C) 2020-2020 Chuan Ji                                         *
+ *                                                                           *
+ *  Licensed under the Apache License, Version 2.0 (the "License");          *
+ *  you may not use this file except in compliance with the License.         *
+ *  You may obtain a copy of the License at                                  *
+ *                                                                           *
+ *   http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                           *
+ *  Unless required by applicable law or agreed to in writing, software      *
+ *  distributed under the License is distributed on an "AS IS" BASIS,        *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *  See the License for the specific language governing permissions and      *
+ *  limitations under the License.                                           *
+ *                                                                           *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+// This file provides a collection of utilities for working with fitz
+// constructs.
+
+#ifndef FITZ_UTILS_HPP
+#define FITZ_UTILS_HPP
+
+extern "C" {
+#include "mupdf/fitz.h"
+}
+
+// Constructs a transformation matrix from the given parameters.
+extern fz_matrix ComputeTransformMatrix(float zoom, int rotation);
+
+#endif
+

--- a/src/image_document.cpp
+++ b/src/image_document.cpp
@@ -20,7 +20,7 @@
 // abstraction using Imlib2. If the macro JFBVIEW_NO_IMLIB2 is defined, this
 // file is disabled.
 
-#ifndef JFBVIEW_NO_IMLIB2
+#if defined(JFBVIEW_ENABLE_LEGACY_IMAGE_IMPL) && !defined(JFBVIEW_NO_IMLIB2)
 
 #include "image_document.hpp"
 

--- a/src/image_document.hpp
+++ b/src/image_document.hpp
@@ -20,13 +20,14 @@
 // abstraction using Imlib2. If the macro JFBVIEW_NO_IMLIB2 is defined, this
 // class is disabled.
 
-#ifndef JFBVIEW_NO_IMLIB2
+#if defined(JFBVIEW_ENABLE_LEGACY_IMAGE_IMPL) && !defined(JFBVIEW_NO_IMLIB2)
 
 #ifndef IMAGE_DOCUMENT_HPP
 #define IMAGE_DOCUMENT_HPP
 
 #include <string>
 #include <vector>
+
 #include "Imlib2.h"
 #include "document.hpp"
 
@@ -38,21 +39,15 @@ class ImageDocument : public Document {
   // path to an image file. Returns nullptr if the file cannot be opened.
   static Document* Open(const std::string& path);
   // See Document.
-  int GetNumPages() override {
-    return 1;
-  }
+  int GetNumPages() override { return 1; }
   // See Document.
   const PageSize GetPageSize(int page, float zoom, int rotation) override;
   // See Document. Thread-safe.
   void Render(PixelWriter* pw, int page, float zoom, int rotation) override;
   // See Document.
-  const OutlineItem* GetOutline()  override {
-    return nullptr;
-  }
+  const OutlineItem* GetOutline() override { return nullptr; }
   // See Document.
-  int Lookup(const OutlineItem* item)  override {
-    return -1;
-  }
+  int Lookup(const OutlineItem* item) override { return -1; }
 
  protected:
   // See Document.
@@ -71,7 +66,7 @@ class ImageDocument : public Document {
   explicit ImageDocument(Imlib_Image image);
   // We disallow copying because we store lots of heap allocated state.
   explicit ImageDocument(const ImageDocument& other);
-  ImageDocument& operator = (const ImageDocument& other);
+  ImageDocument& operator=(const ImageDocument& other);
 };
 
 #endif

--- a/src/jpdfcat.cpp
+++ b/src/jpdfcat.cpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 
+#include "fitz_document.hpp"
 #include "pdf_document.hpp"
 
 namespace {
@@ -97,8 +98,13 @@ int JpdfcatMain(int argc, char* argv[]) {
   Options options;
   ParseCommandLine(argc, argv, &options);
 
+#ifdef JFBVIEW_ENABLE_LEGACY_PDF_IMPL
   std::unique_ptr<PDFDocument> document(
       PDFDocument::Open(options.FilePath, options.FilePassword.get()));
+#else
+  std::unique_ptr<FitzDocument> document(
+      FitzDocument::Open(options.FilePath, options.FilePassword.get()));
+#endif
   if (!document) {
     fprintf(stderr, "Failed to open \"%s\"\n", options.FilePath.c_str());
     return EXIT_FAILURE;

--- a/src/jpdfgrep.cpp
+++ b/src/jpdfgrep.cpp
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <string>
 
+#include "fitz_document.hpp"
 #include "pdf_document.hpp"
 
 namespace {
@@ -111,8 +112,13 @@ int JpdfgrepMain(int argc, char* argv[]) {
   Options options;
   ParseCommandLine(argc, argv, &options);
 
-  std::unique_ptr<PDFDocument> document(
-      PDFDocument::Open(options.FilePath, options.FilePassword.get()));
+  std::unique_ptr<Document> document(
+#ifdef JFBVIEW_ENABLE_LEGACY_PDF_IMPL
+      PDFDocument::Open(options.FilePath, options.FilePassword.get())
+#else
+      FitzDocument::Open(options.FilePath, options.FilePassword.get())
+#endif
+  );
   if (!document) {
     fprintf(stderr, "Failed to open \"%s\"\n", options.FilePath.c_str());
     return EXIT_FAILURE;

--- a/src/pdf_document.cpp
+++ b/src/pdf_document.cpp
@@ -19,6 +19,8 @@
 // This file defines PDFDocument, an implementation of the Document abstraction
 // using MuPDF.
 
+#ifdef JFBVIEW_ENABLE_LEGACY_IMAGE_IMPL
+
 #include <algorithm>
 #include <cassert>
 #include <cstring>
@@ -451,3 +453,6 @@ fz_irect PDFDocument::GetBoundingBox(
           pdf_bound_page(_fz_context, _pdf_document, page_struct, &bbox), &m));
 #endif
 }
+
+#endif
+

--- a/src/pdf_document.cpp
+++ b/src/pdf_document.cpp
@@ -114,50 +114,48 @@ const char* const PDFDocument::DEFAULT_ROOT_OUTLINE_ITEM_TITLE =
 
 PDFDocument* PDFDocument::Open(
     const std::string& path, const std::string* password, int page_cache_size) {
-  fz_context* context = fz_new_context(nullptr, nullptr, FZ_STORE_DEFAULT);
-  pdf_document* raw_pdf_document = nullptr;
-  fz_try(context) {
-    raw_pdf_document = pdf_open_document(context, path.c_str());
-    if ((raw_pdf_document == nullptr) ||
-        (!pdf_count_pages(context, raw_pdf_document))) {
+  fz_context* ctx = fz_new_context(nullptr, nullptr, FZ_STORE_DEFAULT);
+  pdf_document* doc = nullptr;
+  fz_try(ctx) {
+    doc = pdf_open_document(ctx, path.c_str());
+    if ((doc == nullptr) || (!pdf_count_pages(ctx, doc))) {
       fz_throw(
-          context, FZ_ERROR_GENERIC,
+          ctx, FZ_ERROR_GENERIC,
           const_cast<char*>("Cannot open document \"%s\""), path.c_str());
     }
-    if (pdf_needs_password(context, raw_pdf_document)) {
+    if (pdf_needs_password(ctx, doc)) {
       if (password == nullptr) {
         fz_throw(
-            context, FZ_ERROR_GENERIC,
+            ctx, FZ_ERROR_GENERIC,
             const_cast<char*>(
                 "Document \"%s\" is password protected.\n"
                 "Please provide the password with \"-P <password>\"."),
             path.c_str());
       }
-      if (!pdf_authenticate_password(
-              context, raw_pdf_document, password->c_str())) {
+      if (!pdf_authenticate_password(ctx, doc, password->c_str())) {
         fz_throw(
-            context, FZ_ERROR_GENERIC,
+            ctx, FZ_ERROR_GENERIC,
             const_cast<char*>("Incorrect password for document \"%s\"."),
             path.c_str());
       }
     }
   }
-  fz_catch(context) {
-    if (raw_pdf_document != nullptr) {
-      pdf_drop_document(context, raw_pdf_document);
+  fz_catch(ctx) {
+    if (doc != nullptr) {
+      pdf_drop_document(ctx, doc);
     }
-    fz_drop_context(context);
+    fz_drop_context(ctx);
     return nullptr;
   }
 
 #if MUPDF_VERSION >= 10016
   fz_set_warning_callback(
-      context, [](void* user, const char* message) {}, nullptr);
+      ctx, [](void* user, const char* message) {}, nullptr);
 #endif
 
   PDFDocument* document = new PDFDocument(page_cache_size);
-  document->_fz_context = context;
-  document->_pdf_document = raw_pdf_document;
+  document->_fz_context = ctx;
+  document->_pdf_document = doc;
   return document;
 }
 

--- a/src/pdf_document.hpp
+++ b/src/pdf_document.hpp
@@ -19,6 +19,8 @@
 // This file declares PDFDocument, an implementation of the Document abstraction
 // using MuPDF.
 
+#ifdef JFBVIEW_ENABLE_LEGACY_IMAGE_IMPL
+
 #ifndef PDF_DOCUMENT_HPP
 #define PDF_DOCUMENT_HPP
 
@@ -148,3 +150,6 @@ class PDFDocument : public Document {
 };
 
 #endif
+
+#endif
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Tests.
 # ------
 
-if(ENABLE_IMAGE_SUPPORT)
+if(ENABLE_LEGACY_IMAGE_IMPL AND ENABLE_IMAGE_SUPPORT)
   add_executable(image_document_test image_document_test.cpp)
   target_link_libraries(
     image_document_test
@@ -25,17 +25,19 @@ if(ENABLE_IMAGE_SUPPORT)
   )
 endif()
 
-add_executable(pdf_document_test pdf_document_test.cpp)
-target_link_libraries(
-  pdf_document_test
-  jfbview_document
-  ${GTEST_BOTH_LIBRARIES}
-)
-add_test(
-  NAME pdf_document_test
-  COMMAND pdf_document_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+if(ENABLE_LEGACY_PDF_IMPL)
+  add_executable(pdf_document_test pdf_document_test.cpp)
+  target_link_libraries(
+    pdf_document_test
+    jfbview_document
+    ${GTEST_BOTH_LIBRARIES}
+  )
+  add_test(
+    NAME pdf_document_test
+    COMMAND pdf_document_test
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+endif()
 
 add_executable(fitz_document_pdf_test fitz_document_pdf_test.cpp)
 target_link_libraries(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,18 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+add_executable(fitz_document_test fitz_document_test.cpp)
+target_link_libraries(
+  fitz_document_test
+  jfbview_document
+  ${GTEST_BOTH_LIBRARIES}
+)
+add_test(
+  NAME fitz_document_test
+  COMMAND fitz_document_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 add_test(
   NAME smoke_test
   COMMAND

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,15 +37,27 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-add_executable(fitz_document_test fitz_document_test.cpp)
+add_executable(fitz_document_pdf_test fitz_document_pdf_test.cpp)
 target_link_libraries(
-  fitz_document_test
+  fitz_document_pdf_test
   jfbview_document
   ${GTEST_BOTH_LIBRARIES}
 )
 add_test(
-  NAME fitz_document_test
-  COMMAND fitz_document_test
+  NAME fitz_document_pdf_test
+  COMMAND fitz_document_pdf_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_executable(fitz_document_image_test fitz_document_image_test.cpp)
+target_link_libraries(
+  fitz_document_image_test
+  jfbview_document
+  ${GTEST_BOTH_LIBRARIES}
+)
+add_test(
+  NAME fitz_document_image_test
+  COMMAND fitz_document_image_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/tests/fitz_document_image_test.cpp
+++ b/tests/fitz_document_image_test.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "../src/fitz_document.hpp"
+
+// Fitz scales images to a DPI of 72. Our test images have DPI 96.
+inline int ScaleToFitzDpi(int x) { return x * 72 / 96; }
+
+TEST(FitzDocumentImage, ReturnsNullptrIfLoadingEmptyImage) {
+  std::unique_ptr<Document> doc(FitzDocument::Open("", nullptr));
+  EXPECT_EQ(doc.get(), nullptr);
+}
+
+TEST(FitzDocumentImage, CanLoadPNGImage) {
+  std::unique_ptr<Document> doc(
+      FitzDocument::Open("testdata/panda.png", nullptr));
+  EXPECT_NE(doc.get(), nullptr);
+  EXPECT_EQ(doc->GetNumPages(), 1);
+  EXPECT_EQ(doc->GetPageSize(0).Width, ScaleToFitzDpi(160));
+  EXPECT_EQ(doc->GetPageSize(0).Height, ScaleToFitzDpi(200));
+}
+
+TEST(FitzDocumentImage, CanLoadJPEGImage) {
+  std::unique_ptr<Document> doc(
+      FitzDocument::Open("testdata/panda.jpg", nullptr));
+  EXPECT_NE(doc.get(), nullptr);
+  EXPECT_EQ(doc->GetNumPages(), 1);
+  EXPECT_EQ(doc->GetPageSize(0).Width, ScaleToFitzDpi(320));
+  EXPECT_EQ(doc->GetPageSize(0).Height, ScaleToFitzDpi(400));
+}
+

--- a/tests/fitz_document_pdf_test.cpp
+++ b/tests/fitz_document_pdf_test.cpp
@@ -107,7 +107,7 @@ TEST(FitzDocumentPDF, MultithreadedAccess) {
   EXPECT_NE(doc.get(), nullptr);
   std::vector<std::thread> threads;
   srand(time(nullptr));
-  for (int i = 0; i < 10; ++i) {
+  for (int i = 0; i < 20; ++i) {
     threads.push_back(std::thread([&doc, i]() {
       for (int page = 0; page < doc->GetNumPages(); ++page) {
         const Document::PageSize page_size = doc->GetPageSize(page);
@@ -115,7 +115,7 @@ TEST(FitzDocumentPDF, MultithreadedAccess) {
             << " on page " << (page + 1) << " in thread " << i;
         EXPECT_GT(page_size.Width, 0)
             << " on page " << (page + 1) << " in thread " << i;
-        if (!(rand() % 5)) {
+        if (!(rand() % 10)) {
           DummyPixelWriter dummy_pixel_writer;
           doc->Render(&dummy_pixel_writer, page, 1.0f, 0);
           EXPECT_EQ(
@@ -123,6 +123,8 @@ TEST(FitzDocumentPDF, MultithreadedAccess) {
               page_size.Width * page_size.Height)
               << " on page " << (page + 1) << " in thread " << i;
         }
+        std::unique_ptr<const Document::OutlineItem> outline(doc->GetOutline());
+        EXPECT_NE(outline.get(), nullptr);
       }
     }));
   }

--- a/tests/fitz_document_pdf_test.cpp
+++ b/tests/fitz_document_pdf_test.cpp
@@ -1,17 +1,17 @@
-#include "../src/fitz_document.hpp"
-
 #include <gtest/gtest.h>
 
 #include <cmath>
 #include <memory>
 #include <vector>
 
-TEST(FitzDocument, ReturnsNullptrIfLoadingEmptyDocument) {
+#include "../src/fitz_document.hpp"
+
+TEST(FitzDocumentPDF, ReturnsNullptrIfLoadingEmptyDocument) {
   std::unique_ptr<Document> doc(FitzDocument::Open("", nullptr));
   EXPECT_EQ(doc.get(), nullptr);
 }
 
-TEST(FitzDocument, CanLoadDocument) {
+TEST(FitzDocumentPDF, CanLoadDocument) {
   std::unique_ptr<Document> doc(
       FitzDocument::Open("testdata/bash.pdf", nullptr));
   EXPECT_NE(doc.get(), nullptr);
@@ -23,7 +23,7 @@ TEST(FitzDocument, CanLoadDocument) {
 }
 
 /*
-TEST(FitzDocument, CanLoadOutline) {
+TEST(FitzDocumentPDF, CanLoadOutline) {
   std::unique_ptr<Document> doc(
       FitzDocument::Open("testdata/bash.pdf", nullptr));
   EXPECT_NE(doc.get(), nullptr);
@@ -53,7 +53,7 @@ TEST(FitzDocument, CanLoadOutline) {
   EXPECT_EQ(doc->Lookup(item), 11);
 }
 
-TEST(FitzDocument, CanSearch) {
+TEST(FitzDocumentPDF, CanSearch) {
   std::unique_ptr<Document> doc(
       FitzDocument::Open("testdata/bash.pdf", nullptr));
   EXPECT_NE(doc.get(), nullptr);
@@ -73,7 +73,7 @@ TEST(FitzDocument, CanSearch) {
 
 */
 
-TEST(FitzDocument, CanLoadPasswordProtectedDocument) {
+TEST(FitzDocumentPDF, CanLoadPasswordProtectedDocument) {
   std::unique_ptr<Document> doc(
       FitzDocument::Open("testdata/password-test.pdf", nullptr));
   EXPECT_EQ(doc.get(), nullptr);

--- a/tests/fitz_document_pdf_test.cpp
+++ b/tests/fitz_document_pdf_test.cpp
@@ -1,10 +1,29 @@
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cmath>
+#include <cstdlib>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "../src/fitz_document.hpp"
+
+namespace {
+
+class DummyPixelWriter : public Document::PixelWriter {
+ public:
+  DummyPixelWriter() : call_count(0) {}
+  void Write(int x, int y, uint8_t r, uint8_t g, uint8_t b) override {
+    ++call_count;
+  }
+  int GetCallCount() const { return call_count; }
+
+ private:
+  std::atomic<int> call_count;
+};
+
+}  // namespace
 
 TEST(FitzDocumentPDF, ReturnsNullptrIfLoadingEmptyDocument) {
   std::unique_ptr<Document> doc(FitzDocument::Open("", nullptr));
@@ -22,7 +41,6 @@ TEST(FitzDocumentPDF, CanLoadDocument) {
   EXPECT_EQ(page_size.Width * 1000 / page_size.Height, int(8.5 * 1000 / 11));
 }
 
-/*
 TEST(FitzDocumentPDF, CanLoadOutline) {
   std::unique_ptr<Document> doc(
       FitzDocument::Open("testdata/bash.pdf", nullptr));
@@ -71,8 +89,6 @@ TEST(FitzDocumentPDF, CanSearch) {
   }
 }
 
-*/
-
 TEST(FitzDocumentPDF, CanLoadPasswordProtectedDocument) {
   std::unique_ptr<Document> doc(
       FitzDocument::Open("testdata/password-test.pdf", nullptr));
@@ -81,9 +97,37 @@ TEST(FitzDocumentPDF, CanLoadPasswordProtectedDocument) {
   doc.reset(FitzDocument::Open("testdata/password-test.pdf", &password));
   EXPECT_NE(doc.get(), nullptr);
   EXPECT_EQ(doc->GetNumPages(), 1);
-  /*
   const Document::SearchResult result = doc->Search("SUCCESS", 0, 80, 100);
   EXPECT_EQ(result.SearchHits.size(), 1);
-  */
+}
+
+TEST(FitzDocumentPDF, MultithreadedAccess) {
+  std::unique_ptr<Document> doc(
+      FitzDocument::Open("testdata/bash.pdf", nullptr));
+  EXPECT_NE(doc.get(), nullptr);
+  std::vector<std::thread> threads;
+  srand(time(nullptr));
+  for (int i = 0; i < 10; ++i) {
+    threads.push_back(std::thread([&doc, i]() {
+      for (int page = 0; page < doc->GetNumPages(); ++page) {
+        const Document::PageSize page_size = doc->GetPageSize(page);
+        EXPECT_GT(page_size.Height, 0)
+            << " on page " << (page + 1) << " in thread " << i;
+        EXPECT_GT(page_size.Width, 0)
+            << " on page " << (page + 1) << " in thread " << i;
+        if (!(rand() % 5)) {
+          DummyPixelWriter dummy_pixel_writer;
+          doc->Render(&dummy_pixel_writer, page, 1.0f, 0);
+          EXPECT_EQ(
+              dummy_pixel_writer.GetCallCount(),
+              page_size.Width * page_size.Height)
+              << " on page " << (page + 1) << " in thread " << i;
+        }
+      }
+    }));
+  }
+  for (std::thread& thread : threads) {
+    thread.join();
+  }
 }
 

--- a/tests/fitz_document_test.cpp
+++ b/tests/fitz_document_test.cpp
@@ -1,0 +1,89 @@
+#include "../src/fitz_document.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+TEST(FitzDocument, ReturnsNullptrIfLoadingEmptyDocument) {
+  std::unique_ptr<Document> doc(FitzDocument::Open("", nullptr));
+  EXPECT_EQ(doc.get(), nullptr);
+}
+
+TEST(FitzDocument, CanLoadDocument) {
+  std::unique_ptr<Document> doc(
+      FitzDocument::Open("testdata/bash.pdf", nullptr));
+  EXPECT_NE(doc.get(), nullptr);
+  EXPECT_EQ(doc->GetNumPages(), 186);
+  const Document::PageSize page_size = doc->GetPageSize(0);
+  EXPECT_GT(page_size.Height, 0);
+  EXPECT_GT(page_size.Width, 0);
+  EXPECT_EQ(page_size.Width * 1000 / page_size.Height, int(8.5 * 1000 / 11));
+}
+
+/*
+TEST(FitzDocument, CanLoadOutline) {
+  std::unique_ptr<Document> doc(
+      FitzDocument::Open("testdata/bash.pdf", nullptr));
+  EXPECT_NE(doc.get(), nullptr);
+  std::unique_ptr<const Document::OutlineItem> outline(doc->GetOutline());
+  EXPECT_NE(outline.get(), nullptr);
+
+  EXPECT_EQ(outline->GetNumChildren(), 14);
+
+  const Document::OutlineItem* item = outline->GetChild(1);
+  EXPECT_EQ(item->GetTitle(), "Definitions");
+  EXPECT_EQ(item->GetNumChildren(), 0);
+  EXPECT_EQ(doc->Lookup(item), 8);
+
+  item = outline->GetChild(2);
+  EXPECT_EQ(item->GetTitle(), "Basic Shell Features");
+  EXPECT_EQ(item->GetNumChildren(), 8);
+  EXPECT_EQ(doc->Lookup(item), 10);
+
+  item = item->GetChild(0);
+  EXPECT_EQ(item->GetTitle(), "Shell Syntax");
+  EXPECT_EQ(item->GetNumChildren(), 3);
+  EXPECT_EQ(doc->Lookup(item), 10);
+
+  item = item->GetChild(1);
+  EXPECT_EQ(item->GetTitle(), "Quoting");
+  EXPECT_EQ(item->GetNumChildren(), 5);
+  EXPECT_EQ(doc->Lookup(item), 11);
+}
+
+TEST(FitzDocument, CanSearch) {
+  std::unique_ptr<Document> doc(
+      FitzDocument::Open("testdata/bash.pdf", nullptr));
+  EXPECT_NE(doc.get(), nullptr);
+  const Document::SearchResult result = doc->Search("HISTIGNORE", 0, 80, 100);
+  EXPECT_EQ(result.SearchString, "HISTIGNORE");
+  EXPECT_EQ(result.LastSearchedPage, doc->GetNumPages());
+  const std::vector<int> expected_result_pages(
+      {84, 85, 85, 85, 130, 148, 148, 180});
+  EXPECT_EQ(result.SearchHits.size(), expected_result_pages.size());
+  for (int i = 0; i < result.SearchHits.size(); ++i) {
+    const auto& hit = result.SearchHits[i];
+    EXPECT_EQ(hit.Page, expected_result_pages[i]);
+    EXPECT_LE(hit.ContextText.length(), 80);
+    EXPECT_NE(hit.ContextText.find("HISTIGNORE"), std::string::npos);
+  }
+}
+
+*/
+
+TEST(FitzDocument, CanLoadPasswordProtectedDocument) {
+  std::unique_ptr<Document> doc(
+      FitzDocument::Open("testdata/password-test.pdf", nullptr));
+  EXPECT_EQ(doc.get(), nullptr);
+  const std::string password = "abracadabra";
+  doc.reset(FitzDocument::Open("testdata/password-test.pdf", &password));
+  EXPECT_NE(doc.get(), nullptr);
+  EXPECT_EQ(doc->GetNumPages(), 1);
+  /*
+  const Document::SearchResult result = doc->Search("SUCCESS", 0, 80, 100);
+  EXPECT_EQ(result.SearchHits.size(), 1);
+  */
+}
+

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -51,14 +51,14 @@ if ! jpdfcat -h 2>&1 | grep -q 'Options:'; then
 fi
 
 echo 'Checking jpdfcat with test PDF file...'
-num_search_results=$(jpdfcat ./bash.pdf | grep 'HISTIGNORE' | wc -l)
+num_search_results=$(jpdfcat ./bash.pdf | grep -o 'HISTIGNORE' | wc -l)
 if [ $? -ne 0 ] || [ $num_search_results -ne 8 ]; then
   echo 'Invalid output from jpdfcat'
   exit 1
 fi
 
 echo 'Checking jpdfcat with page arguments...'
-num_search_results=$(jpdfcat ./bash.pdf 86 131 | grep 'HISTIGNORE' | wc -l)
+num_search_results=$(jpdfcat ./bash.pdf 86 131 | grep -o 'HISTIGNORE' | wc -l)
 if [ $? -ne 0 ] || [ $num_search_results -ne 4 ]; then
   echo 'Invalid output from jpdfcat'
   exit 1


### PR DESCRIPTION
This PR introduces a single document abstraction on top of MuPDF's Fitz API, replacing  `ImageDocument` (based on Imlib2) and `PDFDocument` (based on MuPDF's low level PDF API).

This has a lot of benefits:

- Drop Imlib2 as a dependency for images
- Opens the door to supporting additional file types via MuPDF (e.g. EPUB, XPS).
- One single document implementation rather than two

This PR still keeps the old `PDFDocument` and `ImageDocument` code around, but hidden behind a CMake flag.