### PR TITLE
Use system-provided libraries for harfbuzz, freetype, zlib and openjpeg.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@ vendor/mupdf/doc/** export-ignore
 vendor/mupdf/thirdparty/curl/** export-ignore
 vendor/mupdf/thirdparty/freeglut/** export-ignore
 vendor/mupdf/thirdparty/libjpeg/** export-ignore
-vendor/mupdf/thirdparty/harfbuzz/test/*/** export-ignore
+vendor/mupdf/thirdparty/harfbuzz/** export-ignore
 vendor/mupdf/thirdparty/lcms2/doc/** export-ignore
 vendor/mupdf/thirdparty/lcms2/testbed/** export-ignore
 vendor/mupdf/thirdparty/zlib/contrib/** export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,5 @@ vendor/mupdf/thirdparty/freetype/** export-ignore
 vendor/mupdf/thirdparty/lcms2/doc/** export-ignore
 vendor/mupdf/thirdparty/lcms2/testbed/** export-ignore
 vendor/mupdf/thirdparty/zlib/** export-ignore
+vendor/mupdf/thirdparty/openjpeg/** export-ignore
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@ vendor/mupdf/thirdparty/curl/** export-ignore
 vendor/mupdf/thirdparty/freeglut/** export-ignore
 vendor/mupdf/thirdparty/libjpeg/** export-ignore
 vendor/mupdf/thirdparty/harfbuzz/** export-ignore
+vendor/mupdf/thirdparty/freetype/** export-ignore
 vendor/mupdf/thirdparty/lcms2/doc/** export-ignore
 vendor/mupdf/thirdparty/lcms2/testbed/** export-ignore
 vendor/mupdf/thirdparty/zlib/contrib/** export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,5 +6,5 @@ vendor/mupdf/thirdparty/harfbuzz/** export-ignore
 vendor/mupdf/thirdparty/freetype/** export-ignore
 vendor/mupdf/thirdparty/lcms2/doc/** export-ignore
 vendor/mupdf/thirdparty/lcms2/testbed/** export-ignore
-vendor/mupdf/thirdparty/zlib/contrib/** export-ignore
+vendor/mupdf/thirdparty/zlib/** export-ignore
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,15 +11,14 @@ jobs:
           submodules: recursive
       - name: Build package
         run: |
-          sudo packaging/build-package-deb.sh ${{github.sha}} ubuntu amd64 && \
-          sudo chown -R $(whoami) upload
+          packaging/build-package-deb.sh ${{github.sha}} ubuntu amd64
       - name: Upload package
         uses: actions/upload-artifact@v2
         with:
           name: jfbview_${{github.sha}}_amd64.deb
           path: upload/*.deb
       - name: Check package
-        run: sudo packaging/check-package-deb.sh
+        run: packaging/check-package-deb.sh
   build-full-source-package:
     name: build full source package
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake settings.
 # ---------------
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 cmake_policy(SET CMP0048 NEW)
 

--- a/cmake/FindHarfBuzz.cmake
+++ b/cmake/FindHarfBuzz.cmake
@@ -1,0 +1,182 @@
+# From https://github.com/WebKit/webkit/blob/master/Source/cmake/FindHarfBuzz.cmake
+
+# Copyright (c) 2012, Intel Corporation
+# Copyright (c) 2019 Sony Interactive Entertainment Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Intel Corporation nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Try to find Harfbuzz include and library directories.
+#
+# After successful discovery, this will set for inclusion where needed:
+# HarfBuzz_INCLUDE_DIRS - containg the HarfBuzz headers
+# HarfBuzz_LIBRARIES - containg the HarfBuzz library
+
+#[=======================================================================[.rst:
+FindHarfBuzz
+--------------
+
+Find HarfBuzz headers and libraries.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``HarfBuzz::HarfBuzz``
+  The HarfBuzz library, if found.
+
+``HarfBuzz::ICU``
+  The HarfBuzz ICU library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables in your project:
+
+``HarfBuzz_FOUND``
+  true if (the requested version of) HarfBuzz is available.
+``HarfBuzz_VERSION``
+  the version of HarfBuzz.
+``HarfBuzz_LIBRARIES``
+  the libraries to link against to use HarfBuzz.
+``HarfBuzz_INCLUDE_DIRS``
+  where to find the HarfBuzz headers.
+``HarfBuzz_COMPILE_OPTIONS``
+  this should be passed to target_compile_options(), if the
+  target is not used for linking
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_HARFBUZZ QUIET harfbuzz)
+set(HarfBuzz_COMPILE_OPTIONS ${PC_HARFBUZZ_CFLAGS_OTHER})
+set(HarfBuzz_VERSION ${PC_HARFBUZZ_CFLAGS_VERSION})
+
+find_path(HarfBuzz_INCLUDE_DIR
+    NAMES hb.h
+    HINTS ${PC_HARFBUZZ_INCLUDEDIR} ${PC_HARFBUZZ_INCLUDE_DIRS}
+    PATH_SUFFIXES harfbuzz
+)
+
+find_library(HarfBuzz_LIBRARY
+    NAMES ${HarfBuzz_NAMES} harfbuzz
+    HINTS ${PC_HARFBUZZ_LIBDIR} ${PC_HARFBUZZ_LIBRARY_DIRS}
+)
+
+if (HarfBuzz_INCLUDE_DIR AND NOT HarfBuzz_VERSION)
+    if (EXISTS "${HarfBuzz_INCLUDE_DIR}/hb-version.h")
+        file(READ "${HarfBuzz_INCLUDE_DIR}/hb-version.h" _harfbuzz_version_content)
+
+        string(REGEX MATCH "#define +HB_VERSION_STRING +\"([0-9]+\.[0-9]+\.[0-9]+)\"" _dummy "${_harfbuzz_version_content}")
+        set(HarfBuzz_VERSION "${CMAKE_MATCH_1}")
+    endif ()
+endif ()
+
+if ("${HarfBuzz_FIND_VERSION}" VERSION_GREATER "${HarfBuzz_VERSION}")
+    message(FATAL_ERROR "Required version (" ${HarfBuzz_FIND_VERSION} ") is higher than found version (" ${HarfBuzz_VERSION} ")")
+endif ()
+
+# Find components
+if (HarfBuzz_INCLUDE_DIR AND HarfBuzz_LIBRARY)
+    set(_HarfBuzz_REQUIRED_LIBS_FOUND ON)
+    set(HarfBuzz_LIBS_FOUND "HarfBuzz (required): ${HarfBuzz_LIBRARY}")
+else ()
+    set(_HarfBuzz_REQUIRED_LIBS_FOUND OFF)
+    set(HarfBuzz_LIBS_NOT_FOUND "HarfBuzz (required)")
+endif ()
+
+if ("ICU" IN_LIST HarfBuzz_FIND_COMPONENTS)
+    pkg_check_modules(PC_HARFBUZZ_ICU QUIET harfbuzz-icu)
+    set(HarfBuzz_ICU_COMPILE_OPTIONS ${PC_HARFBUZZ_ICU_CFLAGS_OTHER})
+
+    find_library(HarfBuzz_ICU_LIBRARY
+        NAMES ${HarfBuzz_ICU_NAMES} harfbuzz-icu
+        HINTS ${PC_HARFBUZZ_ICU_LIBDIR} ${PC_HARFBUZZ_ICU_LIBRARY_DIRS}
+    )
+
+    if (HarfBuzz_ICU_LIBRARY)
+        if (HarfBuzz_FIND_REQUIRED_ICU)
+            list(APPEND HarfBuzz_LIBS_FOUND "ICU (required): ${HarfBuzz_ICU_LIBRARY}")
+        else ()
+           list(APPEND HarfBuzz_LIBS_FOUND "ICU (optional): ${HarfBuzz_ICU_LIBRARY}")
+        endif ()
+    else ()
+        if (HarfBuzz_FIND_REQUIRED_ICU)
+           set(_HarfBuzz_REQUIRED_LIBS_FOUND OFF)
+           list(APPEND HarfBuzz_LIBS_NOT_FOUND "ICU (required)")
+        else ()
+           list(APPEND HarfBuzz_LIBS_NOT_FOUND "ICU (optional)")
+        endif ()
+    endif ()
+endif ()
+
+if (NOT HarfBuzz_FIND_QUIETLY)
+    if (HarfBuzz_LIBS_FOUND)
+        message(STATUS "Found the following HarfBuzz libraries:")
+        foreach (found ${HarfBuzz_LIBS_FOUND})
+            message(STATUS " ${found}")
+        endforeach ()
+    endif ()
+    if (HarfBuzz_LIBS_NOT_FOUND)
+        message(STATUS "The following HarfBuzz libraries were not found:")
+        foreach (found ${HarfBuzz_LIBS_NOT_FOUND})
+            message(STATUS " ${found}")
+        endforeach ()
+    endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HarfBuzz
+    FOUND_VAR HarfBuzz_FOUND
+    REQUIRED_VARS HarfBuzz_INCLUDE_DIR HarfBuzz_LIBRARY _HarfBuzz_REQUIRED_LIBS_FOUND
+    VERSION_VAR HarfBuzz_VERSION
+)
+
+if (HarfBuzz_LIBRARY AND NOT TARGET HarfBuzz::HarfBuzz)
+    add_library(HarfBuzz::HarfBuzz UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(HarfBuzz::HarfBuzz PROPERTIES
+        IMPORTED_LOCATION "${HarfBuzz_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${HarfBuzz_COMPILE_OPTIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${HarfBuzz_INCLUDE_DIR}"
+    )
+endif ()
+
+if (HarfBuzz_ICU_LIBRARY AND NOT TARGET HarfBuzz::ICU)
+    add_library(HarfBuzz::ICU UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(HarfBuzz::ICU PROPERTIES
+        IMPORTED_LOCATION "${HarfBuzz_ICU_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${HarfBuzz_ICU_COMPILE_OPTIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${HarfBuzz_INCLUDE_DIR}"
+    )
+endif ()
+
+mark_as_advanced(
+    HarfBuzz_INCLUDE_DIR
+    HarfBuzz_LIBRARY
+    HarfBuzz_ICU_LIBRARY
+)
+
+if (HarfBuzz_FOUND)
+   set(HarfBuzz_LIBRARIES ${HarfBuzz_LIBRARY} ${HarfBuzz_ICU_LIBRARY})
+   set(HarfBuzz_INCLUDE_DIRS ${HarfBuzz_INCLUDE_DIR})
+endif ()

--- a/cmake/FindOpenJPEG.cmake
+++ b/cmake/FindOpenJPEG.cmake
@@ -1,0 +1,110 @@
+# From https://github.com/WebKit/webkit/blob/master/Source/cmake/FindOpenJPEG.cmake
+
+# Copyright (C) 2019 Sony Interactive Entertainment Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindOpenJPEG
+--------------
+
+Find OpenJPEG headers and libraries.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``OpenJPEG::OpenJPEG``
+  The OpenJPEG library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables in your project:
+
+``OpenJPEG_FOUND``
+  true if (the requested version of) OpenJPEG is available.
+``OpenJPEG_VERSION``
+  the version of OpenJPEG.
+``OpenJPEG_LIBRARIES``
+  the libraries to link against to use OpenJPEG.
+``OpenJPEG_INCLUDE_DIRS``
+  where to find the OpenJPEG headers.
+``OpenJPEG_COMPILE_OPTIONS``
+  this should be passed to target_compile_options(), if the
+  target is not used for linking
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_OPENJPEG QUIET libopenjp2)
+set(OpenJPEG_COMPILE_OPTIONS ${PC_OPENJPEG_CFLAGS_OTHER})
+set(OpenJPEG_VERSION ${PC_OPENJPEG_VERSION})
+
+find_path(OpenJPEG_INCLUDE_DIR
+    NAMES opj_config.h
+    HINTS ${PC_OPENJPEG_INCLUDEDIR} ${PC_OPENJPEG_INCLUDE_DIRS}
+)
+
+find_library(OpenJPEG_LIBRARY
+    NAMES ${OpenJPEG_NAMES} openjp2
+    HINTS ${PC_OPENJPEG_LIBDIR} ${PC_OPENJPEG_LIBRARY_DIRS}
+)
+
+if (OpenJPEG_INCLUDE_DIR AND NOT OpenJPEG_VERSION)
+    if (EXISTS "${OpenJPEG_INCLUDE_DIR}/opj_config.h")
+        file(READ "${OpenJPEG_INCLUDE_DIR}/opj_config.h" OpenJPEG_VERSION_CONTENT)
+
+        string(REGEX MATCH "#define +OPJ_VERSION_MAJOR +([0-9]+)" _dummy "${OpenJPEG_VERSION_CONTENT}")
+        set(OpenJPEG_VERSION_MAJOR "${CMAKE_MATCH_1}")
+
+        string(REGEX MATCH "#define +OPJ_VERSION_MINOR +([0-9]+)" _dummy "${OpenJPEG_VERSION_CONTENT}")
+        set(OpenJPEG_VERSION_MINOR "${CMAKE_MATCH_1}")
+
+        string(REGEX MATCH "#define +OPJ_VERSION_BUILD +([0-9]+)" _dummy "${OpenJPEG_VERSION_CONTENT}")
+        set(OpenJPEG_VERSION_PATCH "${CMAKE_MATCH_1}")
+
+        set(OpenJPEG_VERSION "${OpenJPEG_VERSION_MAJOR}.${OpenJPEG_VERSION_MINOR}.${OpenJPEG_VERSION_PATCH}")
+    endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpenJPEG
+    FOUND_VAR OpenJPEG_FOUND
+    REQUIRED_VARS OpenJPEG_LIBRARY OpenJPEG_INCLUDE_DIR
+    VERSION_VAR OpenJPEG_VERSION
+)
+
+if (OpenJPEG_LIBRARY AND NOT TARGET OpenJPEG::OpenJPEG)
+    add_library(OpenJPEG::OpenJPEG UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(OpenJPEG::OpenJPEG PROPERTIES
+        IMPORTED_LOCATION "${OpenJPEG_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${OpenJPEG_COMPILE_OPTIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${OpenJPEG_INCLUDE_DIR}"
+    )
+endif ()
+
+mark_as_advanced(OpenJPEG_INCLUDE_DIR OpenJPEG_LIBRARY)
+
+if (OpenJPEG_FOUND)
+    set(OpenJPEG_LIBRARIES ${OpenJPEG_LIBRARY})
+    set(OpenJPEG_INCLUDE_DIRS ${OpenJPEG_INCLUDE_DIR})
+endif ()

--- a/doc/README.md
+++ b/doc/README.md
@@ -60,11 +60,19 @@ To build from source, fetch the source code along with transitive dependencies a
 
   - [libjpeg](http://libjpeg.sourceforge.net/) or [libjpeg-turbo](https://libjpeg-turbo.org/)
 
+  - [OpenJPEG / openjp2](https://github.com/uclouvain/openjpeg)
+
+  - [FreeType](https://www.freetype.org/)
+
+  - [HarfBuzz](https://www.freedesktop.org/wiki/Software/HarfBuzz)
+
+  - [zlib](https://www.zlib.net/)
+
 Build-time dependencies:
 
   - C++ compiler with support for C++14 (GCC 4.9+, Clang 3.5+)
 
-  - [CMake](https://cmake.org/) 3.2+
+  - [CMake](https://cmake.org/) 3.3+
 
 #### Source code
 

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Chuan Ji <chuan@jichu4n.com>")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/jichu4n/jfbview")
 set(
   CPACK_DEBIAN_PACKAGE_DEPENDS
-  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}, libharfbuzz0b, libfreetype6"
+  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}, libharfbuzz0b, libfreetype6, zlib1g"
 )
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
@@ -27,7 +27,7 @@ set(CPACK_RPM_PACKAGE_GROUP "Applications/Text")
 set(CPACK_RPM_PACKAGE_URL "https://github.com/jichu4n/jfbview")
 set(
   CPACK_RPM_PACKAGE_REQUIRES
-  "ncurses-libs, ${LIBJPEG_PACKAGE_NAME}, harfbuzz, freetype"
+  "ncurses-libs, ${LIBJPEG_PACKAGE_NAME}, harfbuzz, freetype, zlib"
 )
 # This is needed to prevent a "conflicts with file from package
 # filesystem-XXXX" error.

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Chuan Ji <chuan@jichu4n.com>")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/jichu4n/jfbview")
 set(
   CPACK_DEBIAN_PACKAGE_DEPENDS
-  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}, libharfbuzz0b"
+  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}, libharfbuzz0b, libfreetype6"
 )
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
@@ -27,7 +27,7 @@ set(CPACK_RPM_PACKAGE_GROUP "Applications/Text")
 set(CPACK_RPM_PACKAGE_URL "https://github.com/jichu4n/jfbview")
 set(
   CPACK_RPM_PACKAGE_REQUIRES
-  "ncurses-libs, ${LIBJPEG_PACKAGE_NAME}, harfbuzz"
+  "ncurses-libs, ${LIBJPEG_PACKAGE_NAME}, harfbuzz, freetype"
 )
 # This is needed to prevent a "conflicts with file from package
 # filesystem-XXXX" error.

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Chuan Ji <chuan@jichu4n.com>")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/jichu4n/jfbview")
 set(
   CPACK_DEBIAN_PACKAGE_DEPENDS
-  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}"
+  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}, libharfbuzz0b"
 )
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
@@ -27,7 +27,7 @@ set(CPACK_RPM_PACKAGE_GROUP "Applications/Text")
 set(CPACK_RPM_PACKAGE_URL "https://github.com/jichu4n/jfbview")
 set(
   CPACK_RPM_PACKAGE_REQUIRES
-  "ncurses-libs, ${LIBJPEG_PACKAGE_NAME}"
+  "ncurses-libs, ${LIBJPEG_PACKAGE_NAME}, harfbuzz"
 )
 # This is needed to prevent a "conflicts with file from package
 # filesystem-XXXX" error.

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Chuan Ji <chuan@jichu4n.com>")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/jichu4n/jfbview")
 set(
   CPACK_DEBIAN_PACKAGE_DEPENDS
-  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}, libharfbuzz0b, libfreetype6, zlib1g"
+  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}, libharfbuzz0b, libfreetype6, zlib1g, libopenjp2-7"
 )
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
@@ -27,7 +27,7 @@ set(CPACK_RPM_PACKAGE_GROUP "Applications/Text")
 set(CPACK_RPM_PACKAGE_URL "https://github.com/jichu4n/jfbview")
 set(
   CPACK_RPM_PACKAGE_REQUIRES
-  "ncurses-libs, ${LIBJPEG_PACKAGE_NAME}, harfbuzz, freetype, zlib"
+  "ncurses-libs, ${LIBJPEG_PACKAGE_NAME}, harfbuzz, freetype, zlib, openjpeg2"
 )
 # This is needed to prevent a "conflicts with file from package
 # filesystem-XXXX" error.

--- a/packaging/build-package-deb.sh
+++ b/packaging/build-package-deb.sh
@@ -25,6 +25,7 @@ function install_build_deps() {
   $sudo apt-get -qq install -y \
     build-essential cmake file \
     libncurses-dev libncursesw5-dev ${libjpeg_dev} \
+    libharfbuzz-dev \
     > /dev/null  # -qq doesn't actually silence apt-get install.
 }
 

--- a/packaging/build-package-deb.sh
+++ b/packaging/build-package-deb.sh
@@ -23,9 +23,9 @@ function install_build_deps() {
   export DEBIAN_FRONTEND=noninteractive
   $sudo apt-get -qq update
   $sudo apt-get -qq install -y \
-    build-essential cmake file \
+    build-essential cmake file pkg-config \
     libncurses-dev libncursesw5-dev ${libjpeg_dev} \
-    libharfbuzz-dev \
+    libharfbuzz-dev libfreetype6-dev \
     > /dev/null  # -qq doesn't actually silence apt-get install.
 }
 

--- a/packaging/build-package-deb.sh
+++ b/packaging/build-package-deb.sh
@@ -25,7 +25,7 @@ function install_build_deps() {
   $sudo apt-get -qq install -y \
     build-essential cmake file pkg-config \
     libncurses-dev libncursesw5-dev ${libjpeg_dev} \
-    libharfbuzz-dev libfreetype6-dev \
+    libharfbuzz-dev libfreetype6-dev zlib1g-dev\
     > /dev/null  # -qq doesn't actually silence apt-get install.
 }
 

--- a/packaging/build-package-deb.sh
+++ b/packaging/build-package-deb.sh
@@ -25,7 +25,7 @@ function install_build_deps() {
   $sudo apt-get -qq install -y \
     build-essential cmake file pkg-config \
     libncurses-dev libncursesw5-dev ${libjpeg_dev} \
-    libharfbuzz-dev libfreetype6-dev zlib1g-dev\
+    libharfbuzz-dev libfreetype6-dev zlib1g-dev libopenjp2-7-dev \
     > /dev/null  # -qq doesn't actually silence apt-get install.
 }
 

--- a/packaging/build-package-rpm.sh
+++ b/packaging/build-package-rpm.sh
@@ -16,7 +16,7 @@ function install_build_deps() {
   $sudo yum install -y -q \
     cmake make gcc-c++ rpm-build \
     ncurses-devel libjpeg-turbo-devel \
-    harfbuzz-devel
+    harfbuzz-devel freetype-devel
 }
 
 function build_package() {

--- a/packaging/build-package-rpm.sh
+++ b/packaging/build-package-rpm.sh
@@ -17,6 +17,11 @@ function install_build_deps() {
     cmake make gcc-c++ rpm-build \
     ncurses-devel libjpeg-turbo-devel \
     harfbuzz-devel freetype-devel zlib-devel
+  if [ -e /etc/centos-release ]; then
+    $sudo dnf --enablerepo=PowerTools install -y -q openjpeg2-devel
+  else
+    $sudo yum install -y -q openjpeg2-devel
+  fi
 }
 
 function build_package() {

--- a/packaging/build-package-rpm.sh
+++ b/packaging/build-package-rpm.sh
@@ -16,7 +16,7 @@ function install_build_deps() {
   $sudo yum install -y -q \
     cmake make gcc-c++ rpm-build \
     ncurses-devel libjpeg-turbo-devel \
-    harfbuzz-devel freetype-devel
+    harfbuzz-devel freetype-devel zlib-devel
 }
 
 function build_package() {

--- a/packaging/build-package-rpm.sh
+++ b/packaging/build-package-rpm.sh
@@ -15,8 +15,8 @@ function install_build_deps() {
   $sudo yum install -y -q epel-release
   $sudo yum install -y -q \
     cmake make gcc-c++ rpm-build \
-    ncurses-devel \
-    libjpeg-turbo-devel
+    ncurses-devel libjpeg-turbo-devel \
+    harfbuzz-devel
 }
 
 function build_package() {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,10 @@ target_link_libraries(
   ${vendor_mupdf_libs}
   ${imlib2_libs}
 )
+add_dependencies(
+  jfbview_document
+  vendor_mupdf
+)
 if(ENABLE_LEGACY_PDF_IMPL)
   add_dependencies(
     jfbview_document

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -2,6 +2,7 @@
 # -------------
 find_package(JPEG REQUIRED)
 find_package(HarfBuzz REQUIRED)
+find_package(Freetype REQUIRED)
 
 # MuPDF provides its own version of libjpeg in thirdparty. However, we are
 # linking against the system version of Imlib2, which links against the system
@@ -15,6 +16,7 @@ add_custom_command(
       "USE_SYSTEM_LIBS=no"
       "USE_SYSTEM_LIBJPEG=yes"
       "USE_SYSTEM_HARFBUZZ=yes"
+      "USE_SYSTEM_FREETYPE=yes"
       "prefix=${CMAKE_CURRENT_BINARY_DIR}/mupdf"
       libs
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mupdf"
@@ -28,6 +30,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/mupdf/include"
   "${JPEG_INCLUDE_DIR}"
   "${HarfBuzz_INCLUDE_DIRS}"
+  "${FREETYPE_INCLUDE_DIRS}"
   PARENT_SCOPE
 )
 set(vendor_mupdf_link_dirs "${CMAKE_CURRENT_SOURCE_DIR}/mupdf/build/release" PARENT_SCOPE)
@@ -37,6 +40,7 @@ set(
   "mupdf-third"
   ${JPEG_LIBRARIES}
   ${HarfBuzz_LIBRARIES}
+  ${FREETYPE_LIBRARIES}
   PARENT_SCOPE
 )
 

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Dependencies.
 # -------------
 find_package(JPEG REQUIRED)
+find_package(HarfBuzz REQUIRED)
 
 # MuPDF provides its own version of libjpeg in thirdparty. However, we are
 # linking against the system version of Imlib2, which links against the system
@@ -13,6 +14,7 @@ add_custom_command(
     make
       "USE_SYSTEM_LIBS=no"
       "USE_SYSTEM_LIBJPEG=yes"
+      "USE_SYSTEM_HARFBUZZ=yes"
       "prefix=${CMAKE_CURRENT_BINARY_DIR}/mupdf"
       libs
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mupdf"
@@ -25,6 +27,7 @@ set(
   vendor_mupdf_include_dirs
   "${CMAKE_CURRENT_SOURCE_DIR}/mupdf/include"
   "${JPEG_INCLUDE_DIR}"
+  "${HarfBuzz_INCLUDE_DIRS}"
   PARENT_SCOPE
 )
 set(vendor_mupdf_link_dirs "${CMAKE_CURRENT_SOURCE_DIR}/mupdf/build/release" PARENT_SCOPE)
@@ -33,6 +36,7 @@ set(
   "mupdf"
   "mupdf-third"
   ${JPEG_LIBRARIES}
+  ${HarfBuzz_LIBRARIES}
   PARENT_SCOPE
 )
 

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -3,6 +3,7 @@
 find_package(JPEG REQUIRED)
 find_package(HarfBuzz REQUIRED)
 find_package(Freetype REQUIRED)
+find_package(ZLIB REQUIRED)
 
 # MuPDF provides its own version of libjpeg in thirdparty. However, we are
 # linking against the system version of Imlib2, which links against the system
@@ -17,6 +18,7 @@ add_custom_command(
       "USE_SYSTEM_LIBJPEG=yes"
       "USE_SYSTEM_HARFBUZZ=yes"
       "USE_SYSTEM_FREETYPE=yes"
+      "USE_SYSTEM_ZLIB=yes"
       "prefix=${CMAKE_CURRENT_BINARY_DIR}/mupdf"
       libs
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mupdf"
@@ -31,6 +33,7 @@ set(
   "${JPEG_INCLUDE_DIR}"
   "${HarfBuzz_INCLUDE_DIRS}"
   "${FREETYPE_INCLUDE_DIRS}"
+  "${ZLIB_INCLUDE_DIRS}"
   PARENT_SCOPE
 )
 set(vendor_mupdf_link_dirs "${CMAKE_CURRENT_SOURCE_DIR}/mupdf/build/release" PARENT_SCOPE)
@@ -41,6 +44,7 @@ set(
   ${JPEG_LIBRARIES}
   ${HarfBuzz_LIBRARIES}
   ${FREETYPE_LIBRARIES}
+  ${ZLIB_LIBRARIES}
   PARENT_SCOPE
 )
 

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(JPEG REQUIRED)
 find_package(HarfBuzz REQUIRED)
 find_package(Freetype REQUIRED)
 find_package(ZLIB REQUIRED)
+find_package(OpenJPEG REQUIRED)
 
 # MuPDF provides its own version of libjpeg in thirdparty. However, we are
 # linking against the system version of Imlib2, which links against the system
@@ -19,6 +20,7 @@ add_custom_command(
       "USE_SYSTEM_HARFBUZZ=yes"
       "USE_SYSTEM_FREETYPE=yes"
       "USE_SYSTEM_ZLIB=yes"
+      "USE_SYSTEM_OPENJPEG=yes"
       "prefix=${CMAKE_CURRENT_BINARY_DIR}/mupdf"
       libs
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mupdf"
@@ -34,6 +36,7 @@ set(
   "${HarfBuzz_INCLUDE_DIRS}"
   "${FREETYPE_INCLUDE_DIRS}"
   "${ZLIB_INCLUDE_DIRS}"
+  "${OpenJPEG_INCLUDE_DIRS}"
   PARENT_SCOPE
 )
 set(vendor_mupdf_link_dirs "${CMAKE_CURRENT_SOURCE_DIR}/mupdf/build/release" PARENT_SCOPE)
@@ -45,6 +48,7 @@ set(
   ${HarfBuzz_LIBRARIES}
   ${FREETYPE_LIBRARIES}
   ${ZLIB_LIBRARIES}
+  ${OpenJPEG_LIBRARIES}
   PARENT_SCOPE
 )
 


### PR DESCRIPTION
Use system (distro-provided) harfbuzz, freetype, zlib and openjpeg libraries rather than the versions bundled in MuPDF.

These libraries are commonly available on all distros and have stable APIs, so using the bundled version has little benefit. Switching to the system version decreases the binary size (although not all that much in proportion to MuPDF itself), and improves the build time significantly from 5-6 mins to 3-4 mins as measured on x86_64.