### PR TITLE
Add explicit dependency from jfbview_document to vendor_mupdf to fix CMake error.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,10 @@ target_link_libraries(
   ${vendor_mupdf_libs}
   ${imlib2_libs}
 )
+add_dependencies(
+  jfbview_document
+  vendor_mupdf
+)
 if(ENABLE_LEGACY_PDF_IMPL)
   add_dependencies(
     jfbview_document


### PR DESCRIPTION
This PR fixes an error introduced by PR #56, where with the default flags we're lacking an explicit dependency between the `jfbview_document` target and `vendor_mupdf`.