### PR TITLE
autoreload added

### DIFF
--- a/doc/jfbview.1
+++ b/doc/jfbview.1
@@ -39,6 +39,9 @@ Start in inverted color mode.
 \fB--color_mode=\fRsepia, \fB-c\fR sepia
 Start in sepia color mode.
 .TP
+\fB--autoreload\fR, \fB-a\fR
+Reload current file once it changes.
+.TP
 \fB--cache_size=\fRn
 Selects the number of pages to cache. jfbview has a in-memory cache of pages
 rendered at a particular zoom and rotation setting. However, you may wish to

--- a/doc/jfbview.1.html
+++ b/doc/jfbview.1.html
@@ -48,6 +48,9 @@
        <B>--color_mode=</B>sepia, <B>-c</B> sepia
               Start in sepia color mode.
 
+       <B>--autoreload</B>, <B>-a</B>
+              Reload current file once it changes.
+
        <B>--cache_size=</B>n
               Selects  the  number  of pages to cache. jfbview has a in-memory
               cache of pages rendered at a particular zoom and  rotation  set‐


### PR DESCRIPTION
some things about that:
[main.cpp#L861](https://github.com/WuerfelDev/jfbview/blob/13d1295dbc864b9d3279830e5e0695742ad4852b/src/main.cpp#L861): This could be replaced with nodelay or removed. Not sure what is best

[main.cpp#914](https://github.com/WuerfelDev/jfbview/blob/13d1295dbc864b9d3279830e5e0695742ad4852b/src/main.cpp#L914): Since halfdelay is set, this is non-blocking and therefore currently only useful if typed at a speed of <0.1s per character

[main.cpp#933](https://github.com/WuerfelDev/jfbview/blob/13d1295dbc864b9d3279830e5e0695742ad4852b/src/main.cpp#L933): the inotify watch fires multiple times for a file change, we could act only after checking the content of the inotify event, the usleep is a little workaround to lower the  risk of loading an incomplete document

[main.cpp#936](https://github.com/WuerfelDev/jfbview/blob/13d1295dbc864b9d3279830e5e0695742ad4852b/src/main.cpp#L936): Is there a fancier way of doing this?