### PR TITLE
Update dependency libncurses from 5 to 6

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Chuan Ji <chuan@jichu4n.com>")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/jichu4n/jfbview")
 set(
   CPACK_DEBIAN_PACKAGE_DEPENDS
-  "libncurses5, libncursesw5, ${LIBJPEG_PACKAGE_NAME}, libharfbuzz0b, libfreetype6, zlib1g, libopenjp2-7"
+  "libncurses6, libncursesw6, ${LIBJPEG_PACKAGE_NAME}, libharfbuzz0b, libfreetype6, zlib1g, libopenjp2-7"
 )
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 


### PR DESCRIPTION
In the build directory, "make package" fails to run due to the outdated dependency _libncurses_. 

We can change the dependency version from 5 to 6 if you wish to explicitly state the dependency's existence -- otherwise, we can remove mention of the dependencies altogether from the same line and Cmake will automatically detect its existence and find an appropriate version. 

Either way, this needs to be updated to run the "make package" command to generate .deb files for latest Linux distributions. 